### PR TITLE
refactor(core): Abstract parameter manager atomic operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,46 @@ NVM module must take following path:
 "root/middleware/nvm/nvm/src/nvm.h"
 ```
 
-### **2. C11 compiler support**
-Parameter module utilize C11 *_Atomic* and *_Generic* features, therefore make sure your compiler supports C11 primitives.  
+### **2. Atomic backend configuration**
+The module requires an atomic backend for parameter value access.
+
+By default, it uses the C11 atomic backend. If your compiler does not provide usable C11 atomics, or if your platform already provides its own atomic API, you can switch the module to a port-specific backend through `par_atomic_port.h`.
+
+#### 2.1 When to use `par_atomic_port.h`
+
+Use `par_atomic_port.h` when:
+
+- the compiler does not fully support `<stdatomic.h>`
+- the target platform already provides atomic primitives
+- you want the parameter module to use the RTOS or platform-native atomic implementation
+
+For example, in RT-Thread-based projects, `par_atomic_port.h` can be used to map parameter atomic operations to the RT-Thread atomic API.
+
+#### 2.2 How to enable `par_atomic_port.h`
+
+Atomic backend selection is controlled by `PAR_ATOMIC_BACKEND` in `parameters/src/par_atomic.h`.
+
+Available options:
+
+```c
+#define PAR_ATOMIC_BACKEND_C11   1
+#define PAR_ATOMIC_BACKEND_PORT  2
+````
+
+To use the port backend, define:
+
+```c
+#define PAR_ATOMIC_BACKEND PAR_ATOMIC_BACKEND_PORT
+```
+
+After that, `par_atomic.h` will include `par_atomic_port.h` and use the port-provided atomic types and helpers.
+
+#### 2.3 Notes
+
+* `par_atomic_port.h` must provide all atomic types and operations required by `par_atomic.h`
+* `float32_t` should be stored and loaded by preserving its raw bit representation, not by numeric cast
+* make sure the underlying atomic storage type matches the size of `float`
+* keep all platform-specific atomic adaptation inside `par_atomic_port.h` so the core parameter code does not need to change
 
 ## **Limitations**
  - **Heap Usage:** The module uses malloc during par_init() to allocate RAM space for the parameters based on the configuration table. Ensure your heap is sufficiently sized.
@@ -221,12 +259,13 @@ static const par_cfg_t g_par_table[ePAR_NUM_OF] =
 
 | Configuration | Description |
 | --- | --- |
-| **PAR_CFG_NVM_EN** 			| Enable/Disable usage of NVM for persistant parameters. |
-| **PAR_CFG_NVM_REGION** 		| Select NVM region for Device Parameter storage space. | 
-| **PAR_CFG_DEBUG_EN** 			| Enable/Disable debugging mode. | 
-| **PAR_CFG_ASSERT_EN** 		| Enable/Disable asserts. Shall be disabled in release build!  | 
-| **PAR_DBG_PRINT** 			| Definition of debug print. | 
-| **PAR_ASSERT** 				| Definition of assert. | 
+| **PAR_CFG_NVM_EN**            | Enable/Disable usage of NVM for persistant parameters. |
+| **PAR_CFG_NVM_REGION**        | Select NVM region for Device Parameter storage space. | 
+| **PAR_CFG_DEBUG_EN**          | Enable/Disable debugging mode. |
+| **PAR_CFG_ASSERT_EN**         | Enable/Disable asserts. Shall be disabled in release build!  | 
+| **PAR_DBG_PRINT**             | Definition of debug print. |
+| **PAR_ASSERT**                | Definition of assert. |
+| **PAR_ATOMIC_BACKEND**        | Select atomic backend implementation. |
 
 **5. Call **par_init()** function**
 

--- a/src/par.c
+++ b/src/par.c
@@ -25,9 +25,9 @@
 #include <stdlib.h>
 #include <stdbool.h>
 #include <string.h>
-#include <stdatomic.h>
 
 #include "par.h"
+#include "par_atomic.h"
 #include "par_nvm.h"
 #include "../../par_if.h"
 
@@ -56,13 +56,13 @@ static struct
 /**
  *  Parameter live values divided by its type in RAM
  */
-static _Atomic uint8_t *    gpu8_par_value = NULL;
-static _Atomic int8_t  *    gpi8_par_value = NULL;
-static _Atomic uint16_t *   gpu16_par_value = NULL;
-static _Atomic int16_t  *   gpi16_par_value = NULL;
-static _Atomic uint32_t *   gpu32_par_value = NULL;
-static _Atomic int32_t  *   gpi32_par_value = NULL;
-static _Atomic float32_t *  gpf32_par_value = NULL;
+static par_atomic_u8_t *     gpu8_par_value = NULL;
+static par_atomic_i8_t *     gpi8_par_value = NULL;
+static par_atomic_u16_t *    gpu16_par_value = NULL;
+static par_atomic_i16_t *    gpi16_par_value = NULL;
+static par_atomic_u32_t *    gpu32_par_value = NULL;
+static par_atomic_i32_t *    gpi32_par_value = NULL;
+static par_atomic_f32_t *    gpf32_par_value = NULL;
 
 /**
  *  Address offset by parameter enumeration
@@ -72,29 +72,21 @@ static uint32_t gu32_par_offset[ ePAR_NUM_OF ] = { 0 };
 /**
  *  Private getters and setters
  */
-#define PAR_GET_U8_PRIV(par_num)        atomic_load_explicit( &gpu8_par_value[gu32_par_offset[par_num]], memory_order_relaxed )
-#define PAR_GET_I8_PRIV(par_num)        atomic_load_explicit( &gpi8_par_value[gu32_par_offset[par_num]], memory_order_relaxed )
-#define PAR_GET_U16_PRIV(par_num)       atomic_load_explicit( &gpu16_par_value[gu32_par_offset[par_num]], memory_order_relaxed )
-#define PAR_GET_I16_PRIV(par_num)       atomic_load_explicit( &gpi16_par_value[gu32_par_offset[par_num]], memory_order_relaxed )
-#define PAR_GET_U32_PRIV(par_num)       atomic_load_explicit( &gpu32_par_value[gu32_par_offset[par_num]], memory_order_relaxed )
-#define PAR_GET_I32_PRIV(par_num)       atomic_load_explicit( &gpi32_par_value[gu32_par_offset[par_num]], memory_order_relaxed )
+#define PAR_GET_U8_PRIV(par_num)        PAR_ATOMIC_LOAD(u8, &gpu8_par_value[gu32_par_offset[par_num]])
+#define PAR_GET_I8_PRIV(par_num)        PAR_ATOMIC_LOAD(i8, &gpi8_par_value[gu32_par_offset[par_num]])
+#define PAR_GET_U16_PRIV(par_num)       PAR_ATOMIC_LOAD(u16, &gpu16_par_value[gu32_par_offset[par_num]])
+#define PAR_GET_I16_PRIV(par_num)       PAR_ATOMIC_LOAD(i16, &gpi16_par_value[gu32_par_offset[par_num]])
+#define PAR_GET_U32_PRIV(par_num)       PAR_ATOMIC_LOAD(u32, &gpu32_par_value[gu32_par_offset[par_num]])
+#define PAR_GET_I32_PRIV(par_num)       PAR_ATOMIC_LOAD(i32, &gpi32_par_value[gu32_par_offset[par_num]])
+#define PAR_GET_F32_PRIV(par_num)       PAR_ATOMIC_LOAD(f32, &gpf32_par_value[gu32_par_offset[par_num]])
 
-// NOTICE: "atomic_load_explicit" does not support float data type, therfore using GCC/CLang build-in primitive "__atomic_load" to overcome this limitation
-#define PAR_GET_F32_PRIV(par_num) ({ \
-    float32_t __val; \
-    __atomic_load( &gpf32_par_value[gu32_par_offset[par_num]], &__val, __ATOMIC_RELAXED); \
-    __val; \
-})
-
-#define PAR_SET_U8_PRIV(par_num, val)   atomic_store_explicit( &gpu8_par_value[gu32_par_offset[par_num]], val, memory_order_relaxed )
-#define PAR_SET_I8_PRIV(par_num, val)   atomic_store_explicit( &gpi8_par_value[gu32_par_offset[par_num]], val, memory_order_relaxed )
-#define PAR_SET_U16_PRIV(par_num, val)  atomic_store_explicit( &gpu16_par_value[gu32_par_offset[par_num]], val, memory_order_relaxed )
-#define PAR_SET_I16_PRIV(par_num, val)  atomic_store_explicit( &gpi16_par_value[gu32_par_offset[par_num]], val, memory_order_relaxed )
-#define PAR_SET_U32_PRIV(par_num, val)  atomic_store_explicit( &gpu32_par_value[gu32_par_offset[par_num]], val, memory_order_relaxed )
-#define PAR_SET_I32_PRIV(par_num, val)  atomic_store_explicit( &gpi32_par_value[gu32_par_offset[par_num]], val, memory_order_relaxed )
-
-// NOTICE: "atomic_store_explicit" does not support float data type, therfore using GCC/CLang build-in primitive "__atomic_store" to overcome this limitation
-#define PAR_SET_F32_PRIV(par_num, val)  __atomic_store( &gpf32_par_value[gu32_par_offset[par_num]], &val, memory_order_relaxed )    
+#define PAR_SET_U8_PRIV(par_num, val)   PAR_ATOMIC_STORE(u8, &gpu8_par_value[gu32_par_offset[par_num]], (val))
+#define PAR_SET_I8_PRIV(par_num, val)   PAR_ATOMIC_STORE(i8, &gpi8_par_value[gu32_par_offset[par_num]], (val))
+#define PAR_SET_U16_PRIV(par_num, val)  PAR_ATOMIC_STORE(u16, &gpu16_par_value[gu32_par_offset[par_num]], (val))
+#define PAR_SET_I16_PRIV(par_num, val)  PAR_ATOMIC_STORE(i16, &gpi16_par_value[gu32_par_offset[par_num]], (val))
+#define PAR_SET_U32_PRIV(par_num, val)  PAR_ATOMIC_STORE(u32, &gpu32_par_value[gu32_par_offset[par_num]], (val))
+#define PAR_SET_I32_PRIV(par_num, val)  PAR_ATOMIC_STORE(i32, &gpi32_par_value[gu32_par_offset[par_num]], (val))
+#define PAR_SET_F32_PRIV(par_num, val)  PAR_ATOMIC_STORE(f32, &gpf32_par_value[gu32_par_offset[par_num]], (val))
 
 #if ( PAR_CFG_DEBUG_EN )
 
@@ -1177,17 +1169,17 @@ par_status_t par_bitand_set_u8_fast(const par_num_t par_num, const uint8_t val)
 
     if ( val > range.max.u8 )
     {
-        atomic_fetch_and_explicit( &gpu8_par_value[gu32_par_offset[par_num]], range.max.u8, memory_order_relaxed );
+        PAR_ATOMIC_FETCH_AND(u8, &gpu8_par_value[gu32_par_offset[par_num]], range.max.u8);
         return ePAR_WAR_LIMITED;
     }
     else if ( val < range.min.u8 )
     {
-        atomic_fetch_and_explicit( &gpu8_par_value[gu32_par_offset[par_num]], range.min.u8, memory_order_relaxed );
+        PAR_ATOMIC_FETCH_AND(u8, &gpu8_par_value[gu32_par_offset[par_num]], range.min.u8);
         return ePAR_WAR_LIMITED;
     }
     else
     {
-        atomic_fetch_and_explicit( &gpu8_par_value[gu32_par_offset[par_num]], val, memory_order_relaxed );
+        PAR_ATOMIC_FETCH_AND(u8, &gpu8_par_value[gu32_par_offset[par_num]], val);
         return ePAR_OK;
     }
 }
@@ -1210,17 +1202,17 @@ par_status_t par_bitand_set_u16_fast(const par_num_t par_num, const uint16_t val
 
     if ( val > range.max.u16 )
     {
-        atomic_fetch_and_explicit( &gpu16_par_value[gu32_par_offset[par_num]], range.max.u16, memory_order_relaxed );
+        PAR_ATOMIC_FETCH_AND(u16, &gpu16_par_value[gu32_par_offset[par_num]], range.max.u16);
         return ePAR_WAR_LIMITED;
     }
     else if ( val < range.min.u16 )
     {
-        atomic_fetch_and_explicit( &gpu16_par_value[gu32_par_offset[par_num]], range.min.u16, memory_order_relaxed );
+        PAR_ATOMIC_FETCH_AND(u16, &gpu16_par_value[gu32_par_offset[par_num]], range.min.u16);
         return ePAR_WAR_LIMITED;
     }
     else
     {
-        atomic_fetch_and_explicit( &gpu16_par_value[gu32_par_offset[par_num]], val, memory_order_relaxed );
+        PAR_ATOMIC_FETCH_AND(u16, &gpu16_par_value[gu32_par_offset[par_num]], val);
         return ePAR_OK;
     }
 }
@@ -1243,17 +1235,17 @@ par_status_t par_bitand_set_u32_fast(const par_num_t par_num, const uint32_t val
 
     if ( val > range.max.u32 )
     {
-        atomic_fetch_and_explicit( &gpu32_par_value[gu32_par_offset[par_num]], range.max.u32, memory_order_relaxed );
+        PAR_ATOMIC_FETCH_AND(u32, &gpu32_par_value[gu32_par_offset[par_num]], range.max.u32);
         return ePAR_WAR_LIMITED;
     }
     else if ( val < range.min.u32 )
     {
-        atomic_fetch_and_explicit( &gpu32_par_value[gu32_par_offset[par_num]], range.min.u32, memory_order_relaxed );
+        PAR_ATOMIC_FETCH_AND(u32, &gpu32_par_value[gu32_par_offset[par_num]], range.min.u32);
         return ePAR_WAR_LIMITED;
     }
     else
     {
-        atomic_fetch_and_explicit( &gpu32_par_value[gu32_par_offset[par_num]], val, memory_order_relaxed );
+        PAR_ATOMIC_FETCH_AND(u32, &gpu32_par_value[gu32_par_offset[par_num]], val);
         return ePAR_OK;
     }
 }
@@ -1276,17 +1268,17 @@ par_status_t par_bitor_set_u8_fast(const par_num_t par_num, const uint8_t val)
 
     if ( val > range.max.u8 )
     {
-        atomic_fetch_or_explicit( &gpu8_par_value[gu32_par_offset[par_num]], range.max.u8, memory_order_relaxed );
+        PAR_ATOMIC_FETCH_OR(u8, &gpu8_par_value[gu32_par_offset[par_num]], range.max.u8);
         return ePAR_WAR_LIMITED;
     }
     else if ( val < range.min.u8 )
     {
-        atomic_fetch_or_explicit( &gpu8_par_value[gu32_par_offset[par_num]], range.min.u8, memory_order_relaxed );
+        PAR_ATOMIC_FETCH_OR(u8, &gpu8_par_value[gu32_par_offset[par_num]], range.min.u8);
         return ePAR_WAR_LIMITED;
     }
     else
     {
-        atomic_fetch_or_explicit( &gpu8_par_value[gu32_par_offset[par_num]], val, memory_order_relaxed );
+        PAR_ATOMIC_FETCH_OR(u8, &gpu8_par_value[gu32_par_offset[par_num]], val);
         return ePAR_OK;
     }
 }
@@ -1309,17 +1301,17 @@ par_status_t par_bitor_set_u16_fast(const par_num_t par_num, const uint16_t val)
 
     if ( val > range.max.u16 )
     {
-        atomic_fetch_or_explicit( &gpu16_par_value[gu32_par_offset[par_num]], range.max.u16, memory_order_relaxed );
+        PAR_ATOMIC_FETCH_OR(u16, &gpu16_par_value[gu32_par_offset[par_num]], range.max.u16);
         return ePAR_WAR_LIMITED;
     }
     else if ( val < range.min.u16 )
     {
-        atomic_fetch_or_explicit( &gpu16_par_value[gu32_par_offset[par_num]], range.min.u16, memory_order_relaxed );
+        PAR_ATOMIC_FETCH_OR(u16, &gpu16_par_value[gu32_par_offset[par_num]], range.min.u16);
         return ePAR_WAR_LIMITED;
     }
     else
     {
-        atomic_fetch_or_explicit( &gpu16_par_value[gu32_par_offset[par_num]], val, memory_order_relaxed );
+        PAR_ATOMIC_FETCH_OR(u16, &gpu16_par_value[gu32_par_offset[par_num]], val);
         return ePAR_OK;
     }
 }
@@ -1342,17 +1334,17 @@ par_status_t par_bitor_set_u32_fast(const par_num_t par_num, const uint32_t val)
 
     if ( val > range.max.u32 )
     {
-        atomic_fetch_or_explicit( &gpu32_par_value[gu32_par_offset[par_num]], range.max.u32, memory_order_relaxed );
+        PAR_ATOMIC_FETCH_OR(u32, &gpu32_par_value[gu32_par_offset[par_num]], range.max.u32);
         return ePAR_WAR_LIMITED;
     }
     else if ( val < range.min.u32 )
     {
-        atomic_fetch_or_explicit( &gpu32_par_value[gu32_par_offset[par_num]], range.min.u32, memory_order_relaxed );
+        PAR_ATOMIC_FETCH_OR(u32, &gpu32_par_value[gu32_par_offset[par_num]], range.min.u32);
         return ePAR_WAR_LIMITED;
     }
     else
     {
-        atomic_fetch_or_explicit( &gpu32_par_value[gu32_par_offset[par_num]], val, memory_order_relaxed );
+        PAR_ATOMIC_FETCH_OR(u32, &gpu32_par_value[gu32_par_offset[par_num]], val);
         return ePAR_OK;
     }
 }

--- a/src/par_atomic.h
+++ b/src/par_atomic.h
@@ -1,0 +1,247 @@
+// Copyright (c) 2026 Ziga Miklosic
+// All Rights Reserved
+// This software is under MIT licence (https://opensource.org/licenses/MIT)
+////////////////////////////////////////////////////////////////////////////////
+/**
+*@file      par_atomic.h
+*@brief     Atomic operations API macros and type declarations
+*@author    wdfk-prog
+*@email     1425075683@qq.com
+*@date      09.03.2026
+*@version   V3.0.1
+*@details   This header provides atomic type aliases and helper macros for load,
+*           store, fetch-and, and fetch-or operations. It supports either the
+*           C11 atomic backend or a port-specific backend selected by
+*           PAR_ATOMIC_BACKEND.
+*/
+
+#ifndef PAR_ATOMIC_H
+#define PAR_ATOMIC_H
+
+#include <stdint.h>
+
+////////////////////////////////////////////////////////////////////////////////
+// Definitions
+////////////////////////////////////////////////////////////////////////////////
+
+/**
+ *     C11 atomic backend selector
+ */
+#define PAR_ATOMIC_BACKEND_C11   1
+
+/**
+ *     Port-specific atomic backend selector
+ */
+#define PAR_ATOMIC_BACKEND_PORT  2
+
+#ifndef PAR_ATOMIC_BACKEND
+    /**
+     *     Default atomic backend selection
+     */
+    #define PAR_ATOMIC_BACKEND PAR_ATOMIC_BACKEND_C11
+#endif
+
+/**
+ *     List of integral types supported by atomic load/store helpers
+ *
+ * @param[in]    X - Macro invoked as X(tag, type)
+ */
+#define PAR_ATOMIC_INTEGRAL_TYPE_LIST(X) \
+    X(u8, uint8_t)                       \
+    X(i8, int8_t)                        \
+    X(u16, uint16_t)                     \
+    X(i16, int16_t)                      \
+    X(u32, uint32_t)                     \
+    X(i32, int32_t)
+
+/**
+ *     List of all scalar types supported by atomic helpers
+ *
+ * @param[in]    X - Macro invoked as X(tag, type)
+ */
+#define PAR_ATOMIC_TYPE_LIST(X) \
+    PAR_ATOMIC_INTEGRAL_TYPE_LIST(X) \
+    X(f32, float)
+
+/**
+ *     List of types supported by atomic fetch-and and fetch-or helpers
+ *
+ * @param[in]    X - Macro invoked as X(tag, type)
+ */
+#define PAR_ATOMIC_FETCH_TYPE_LIST(X) \
+    X(u8, uint8_t)                    \
+    X(u16, uint16_t)                  \
+    X(u32, uint32_t)
+
+#if (PAR_ATOMIC_BACKEND == PAR_ATOMIC_BACKEND_C11)
+
+#include <stdatomic.h>
+
+    /**
+     *     Declare atomic typedef for selected scalar type
+     *
+     * @param[in]    tag  - Type tag suffix
+     * @param[in]    type - Scalar type wrapped by _Atomic
+     */
+    #define PAR_ATOMIC_DECLARE_TYPE(tag, type) \
+        typedef _Atomic type par_atomic_##tag##_t;
+
+PAR_ATOMIC_TYPE_LIST(PAR_ATOMIC_DECLARE_TYPE)
+
+    #undef PAR_ATOMIC_DECLARE_TYPE
+
+    /**
+     *     Define atomic load and store helper functions
+     *
+     * @param[in]    tag  - Type tag suffix
+     * @param[in]    type - Scalar type of generated helpers
+     */
+    #define PAR_ATOMIC_DEFINE_LOAD_STORE(tag, type)                                \
+        static inline type par_atomic_load_##tag(const par_atomic_##tag##_t *ptr)  \
+        {                                                                          \
+            return atomic_load_explicit(ptr, memory_order_relaxed);                \
+        }                                                                          \
+                                                                                   \
+        static inline void par_atomic_store_##tag(par_atomic_##tag##_t *ptr,       \
+            type value)                                                            \
+        {                                                                          \
+            atomic_store_explicit(ptr, value, memory_order_relaxed);               \
+        }
+
+PAR_ATOMIC_INTEGRAL_TYPE_LIST(PAR_ATOMIC_DEFINE_LOAD_STORE)
+
+    #undef PAR_ATOMIC_DEFINE_LOAD_STORE
+
+////////////////////////////////////////////////////////////////////////////////
+/**
+*        Load floating-point atomic value
+*
+* @note     "atomic_load_explicit" does not support float data type in this
+*           implementation, therefore GCC/Clang built-in primitive
+*           "__atomic_load" is used instead.
+*
+* @param[in]    ptr - Pointer to atomic floating-point object
+* @return       value - Current floating-point value
+*/
+////////////////////////////////////////////////////////////////////////////////
+static inline float par_atomic_load_f32(const par_atomic_f32_t *ptr)
+{
+    float value;
+
+    __atomic_load(ptr, &value, __ATOMIC_RELAXED);
+
+    return value;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/**
+*        Store floating-point atomic value
+*
+* @note     "atomic_store_explicit" does not support float data type in this
+*           implementation, therefore GCC/Clang built-in primitive
+*           "__atomic_store" is used instead.
+*
+* @param[in]    ptr   - Pointer to atomic floating-point object
+* @param[in]    value - Value to store
+* @return       void
+*/
+////////////////////////////////////////////////////////////////////////////////
+static inline void par_atomic_store_f32(par_atomic_f32_t *ptr, float value)
+{
+    __atomic_store(ptr, &value, __ATOMIC_RELAXED);
+}
+
+    /**
+     *     Define atomic fetch-and helper function
+     *
+     * @param[in]    tag  - Type tag suffix
+     * @param[in]    type - Scalar type of generated helper
+     */
+    #define PAR_ATOMIC_DEFINE_FETCH_AND(tag, type)                                 \
+        static inline type par_atomic_fetch_and_##tag(par_atomic_##tag##_t *ptr,   \
+            type value)                                                            \
+        {                                                                          \
+            return atomic_fetch_and_explicit(ptr, value, memory_order_relaxed);    \
+        }
+
+PAR_ATOMIC_FETCH_TYPE_LIST(PAR_ATOMIC_DEFINE_FETCH_AND)
+
+    #undef PAR_ATOMIC_DEFINE_FETCH_AND
+
+    /**
+     *     Define atomic fetch-or helper function
+     *
+     * @param[in]    tag  - Type tag suffix
+     * @param[in]    type - Scalar type of generated helper
+     */
+    #define PAR_ATOMIC_DEFINE_FETCH_OR(tag, type)                                  \
+        static inline type par_atomic_fetch_or_##tag(par_atomic_##tag##_t *ptr,    \
+            type value)                                                            \
+        {                                                                          \
+            return atomic_fetch_or_explicit(ptr, value, memory_order_relaxed);     \
+        }
+
+PAR_ATOMIC_FETCH_TYPE_LIST(PAR_ATOMIC_DEFINE_FETCH_OR)
+
+    #undef PAR_ATOMIC_DEFINE_FETCH_OR
+
+#elif (PAR_ATOMIC_BACKEND == PAR_ATOMIC_BACKEND_PORT)
+
+#include "../../par_atomic_port.h"
+
+#else
+
+    #error "Unsupported PAR_ATOMIC_BACKEND"
+
+#endif
+
+////////////////////////////////////////////////////////////////////////////////
+/**
+*        Load atomic value by type tag
+*
+* @param[in]    tag - Type tag suffix
+* @param[in]    ptr - Pointer to atomic object
+* @return       value - Current atomic value
+*/
+////////////////////////////////////////////////////////////////////////////////
+#define PAR_ATOMIC_LOAD(tag, ptr)           par_atomic_load_##tag((ptr))
+
+////////////////////////////////////////////////////////////////////////////////
+/**
+*        Store atomic value by type tag
+*
+* @param[in]    tag   - Type tag suffix
+* @param[in]    ptr   - Pointer to atomic object
+* @param[in]    value - Value to store
+* @return       void
+*/
+////////////////////////////////////////////////////////////////////////////////
+#define PAR_ATOMIC_STORE(tag, ptr, value)   par_atomic_store_##tag((ptr), (value))
+
+////////////////////////////////////////////////////////////////////////////////
+/**
+*        Perform atomic fetch-and by type tag
+*
+* @param[in]    tag   - Type tag suffix
+* @param[in]    ptr   - Pointer to atomic object
+* @param[in]    value - Operand for bitwise AND
+* @return       value - Previous atomic value
+*/
+////////////////////////////////////////////////////////////////////////////////
+#define PAR_ATOMIC_FETCH_AND(tag, ptr, value) \
+    par_atomic_fetch_and_##tag((ptr), (value))
+
+////////////////////////////////////////////////////////////////////////////////
+/**
+*        Perform atomic fetch-or by type tag
+*
+* @param[in]    tag   - Type tag suffix
+* @param[in]    ptr   - Pointer to atomic object
+* @param[in]    value - Operand for bitwise OR
+* @return       value - Previous atomic value
+*/
+////////////////////////////////////////////////////////////////////////////////
+#define PAR_ATOMIC_FETCH_OR(tag, ptr, value) \
+    par_atomic_fetch_or_##tag((ptr), (value))
+
+#endif


### PR DESCRIPTION
#### Why to submit this PR

Currently, the `autogen_parameter_manager` in `par.c` directly depends on `<stdatomic.h>` and the C11 atomic interfaces, including `atomic_load_explicit`, `atomic_store_explicit`, `atomic_fetch_and_explicit`, and `atomic_fetch_or_explicit`.

Although this implementation can function properly, it also has several issues:
1. The parameter management module is directly coupled to the C11 atomic interfaces, which is not conducive to porting to toolchains or platforms that do not fully support `stdatomic.h`.
2. The atomic types and operations are scattered in the business code, reducing maintainability.
3. The atomic read and write operations for floating - point types use GCC/Clang built - in primitives to bypass the limitations, and the relevant logic is mixed in the business files, which is not conducive to unified management.
4. There is a lack of a clear backend switching mechanism, making it difficult to conveniently access the platform's custom atomic implementation.

Therefore, this PR is submitted to abstract and encapsulate the atomic operations of the parameter management module, enabling it to support two implementation methods: the C11 backend and the port backend, and reducing the direct dependence of the business code on the underlying atomic implementation details.

#### What is your solution

This PR mainly makes the following adjustments:
1. Create a new `par_atomic.h` under `Third_Party/autogen_parameter_manager/parameters/src/` as the unified abstract header file for atomic operations in the parameter management module.
2. Remove the direct dependence on `<stdatomic.h>` in `par.c` and replace it with including `par_atomic.h`.
3. Modify the type of the parameter value storage array from directly using `_Atomic` to the abstracted type aliases, including:
   - `par_atomic_u8_t`
   - `par_atomic_i8_t`
   - `par_atomic_u16_t`
   - `par_atomic_i16_t`
   - `par_atomic_u32_t`
   - `par_atomic_i32_t`
   - `par_atomic_f32_t`
4. Replace the private macros related to parameter access with abstract interfaces:
   - `PAR_ATOMIC_LOAD`
   - `PAR_ATOMIC_STORE`
   - `PAR_ATOMIC_FETCH_AND`
   - `PAR_ATOMIC_FETCH_OR`
5. Add an atomic backend selection mechanism in `par_atomic.h`:
   - `PAR_ATOMIC_BACKEND_C11`
   - `PAR_ATOMIC_BACKEND_PORT`
   - By default, `PAR_ATOMIC_BACKEND_C11` is used.
6. For the C11 backend, uniformly encapsulate various atomic types and operations in `par_atomic.h`:
   - Load/store operations for integer types
   - Load/store operations for the floating - point type `f32`
   - Fetch - and/fetch - or operations for unsigned integer types
7. For atomic read and write operations of floating - point types, retain the use of `__atomic_load` / `__atomic_store`, but migrate this part of the implementation from the business code to the unified abstraction layer to reduce the internal complexity of `par.c`.
8. Reserve the support capability for the port backend:
   - When `PAR_ATOMIC_BACKEND_PORT` is selected, include `par_atomic_port.h`
   - Facilitate subsequent customized atomic implementation provided by specific platforms

Through these adjustments, the business logic of the parameter management module is decoupled from the underlying atomic mechanism, the code structure becomes clearer, and better scalability and maintainability are provided for the adaptation of different compilers and platforms.

#### Provide the config and bsp
- BSP:
  - Please fill in the verified BSP path, for example, `bsp/stm32/stm32l496 - st - nucleo`.
- .config:
  - Please fill in the configuration items used to verify this module.
  - If the parameter management component is involved, please supplement the relevant component enabling configuration.
- action:
  - Please fill in the CI/Action link triggered by the PR branch in your own repository.