### PR TITLE
feat(parameter): Add parameter value change detection function

### DIFF
--- a/src/par.c
+++ b/src/par.c
@@ -125,7 +125,9 @@ static uint32_t gu32_par_offset[ ePAR_NUM_OF ] = { 0 };
 ////////////////////////////////////////////////////////////////////////////////
 static void         par_allocate_ram_space          (void);
 static par_status_t par_check_table_validy          (const par_cfg_t * const p_par_cfg);
+#if ( 1 == PAR_CFG_NVM_EN )
 static bool         par_is_value_changed            (const par_num_t par_num, const void * p_val);
+#endif /* ( 1 == PAR_CFG_NVM_EN ) */
 
 ////////////////////////////////////////////////////////////////////////////////
 // Functions
@@ -274,6 +276,7 @@ static par_status_t par_check_table_validy(const par_cfg_t * const p_par_cfg)
     return status;
 }
 
+#if ( 1 == PAR_CFG_NVM_EN )
 ////////////////////////////////////////////////////////////////////////////////
 /**
 *        Is parameter value changed
@@ -325,6 +328,7 @@ static bool par_is_value_changed(const par_num_t par_num, const void * p_val)
 
     return value_changed;
 }
+#endif /* ( 1 == PAR_CFG_NVM_EN ) */
 
 ////////////////////////////////////////////////////////////////////////////////
 /**


### PR DESCRIPTION
A parameter value change detection function, par_is_value_changed, protected by the conditional compilation macro PAR_CFG_NVM_EN, has been added. This function is used to determine whether the parameter value has changed. Meanwhile, this function has been integrated into the par_check_table_validy function, and corresponding preprocessing directives for inclusion control have been added.

```log
parameters/src/par.c:292:13: warning: 'par_is_value_changed' defined but not used [-Wunused-function]
  292 | static bool par_is_value_changed(const par_num_t par_num, const void * p_val)
      |             ^~~~~~~~~~~~~~~~~~~~
```