### PR TITLE
perf(core): Optimize parameter ID lookup with hash map

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,251 @@ In order to be part of *General Embedded C Libraries Ecosystem* this module must
 root/middleware/parameters/parameters/"module_space"
 ```
 
+
+## Parameter identification
+
+Each parameter defined in the configuration table contains two identifiers:
+
+- **par_num** – internal parameter index (enumeration)
+- **id** – external parameter identifier
+
+These identifiers serve different purposes and are intentionally separated.
+
+### Internal identifier (`par_num`)
+
+`par_num` is the enumeration defined in `par_cfg.h` and represents the **internal index of a parameter**.
+
+It is primarily used inside firmware code and by the parameter module APIs.
+
+Example:
+
+```c
+par_set(ePAR_TEST_U8, &value);
+````
+
+Characteristics:
+
+* used as an **index into the parameter configuration table**
+* provides **fast and type-safe access** inside firmware
+* may change if parameters are reordered or new parameters are added
+
+Because of this, `par_num` should generally be used **only inside firmware code**.
+
+### External identifier (`id`)
+
+Each parameter also defines a unique **ID** in the configuration table:
+
+```c
+[ePAR_TEST_U8] = {
+    .id = 0,
+    ...
+}
+```
+
+The **ID is intended for external access** to parameters.
+
+Typical use cases include:
+
+* CLI commands
+* PC configuration tools
+* communication protocols (UART / CAN / etc.)
+* parameter import/export
+* diagnostics or logging
+
+To support these use cases, the module provides APIs that operate using parameter IDs:
+
+* `par_set_by_id()`
+* `par_get_by_id()`
+* `par_save_by_id()`
+
+Internally, these functions resolve the ID to the corresponding `par_num` before accessing the parameter.
+
+### Design rationale
+
+Separating internal and external identifiers provides several advantages:
+
+* **Efficient internal access** through `par_num`
+* **Stable external interface** through `id`
+* the ability to **reorder or extend parameters without breaking external tools**
+
+External systems should always reference parameters by **ID**, while firmware code should typically use **par_num**.
+
+### ID allocation guidelines
+
+Parameter IDs must be **unique across the entire parameter table**.
+
+IDs do not need to be sequential, but it is recommended to group them by subsystem for clarity.
+
+Example allocation:
+
+| ID Range | Subsystem         |
+| -------- | ----------------- |
+| 0–99     | Channel 1         |
+| 100–199  | Channel 2         |
+| 200–299  | Channel 3         |
+| 300–399  | Channel 4         |
+| 10000+   | System parameters |
+
+This approach simplifies integration with external tools and communication protocols.
+
+## ID lookup using hash map
+
+To improve parameter lookup by **ID**, the module builds a runtime hash map during `par_init()`.
+
+This hash map is used by APIs such as:
+
+- `par_get_num_by_id()`
+- `par_set_by_id()`
+- `par_get_by_id()`
+- `par_save_by_id()`
+
+Instead of scanning the full parameter table for every ID lookup, the module hashes the parameter ID and directly maps it to the corresponding `par_num`.
+
+### Why a hash map is used
+
+The parameter module supports two access paths:
+
+- **`par_num`** for internal firmware access
+- **`id`** for external access such as CLI, PC tools, and communication protocols
+
+Internal access by `par_num` is naturally efficient because it uses the parameter enumeration as a direct table index.
+
+External access by **ID** is different. Since IDs are user-defined and do not need to be sequential, converting an ID back to `par_num` would otherwise require a linear search through the full parameter table.
+
+A hash map avoids that cost and provides near constant-time lookup for ID-based APIs.
+
+### How it works
+
+During `par_init()`, the module:
+
+1. walks through the parameter configuration table
+2. hashes each parameter ID into a bucket index
+3. stores the mapping:
+
+```text
+ID -> par_num
+````
+
+Later, when an external API uses an ID, the module:
+
+1. hashes the requested ID
+2. checks the corresponding bucket
+3. returns the mapped `par_num`
+4. performs the actual parameter operation internally
+
+Conceptually:
+
+```text
+External ID
+   |
+   v
+ hash(id)
+   |
+   v
+ hash bucket
+   |
+   v
+ par_num
+   |
+   v
+ internal parameter API
+```
+
+### Why this is better than linear search
+
+Compared to a linear scan of the parameter table, the hash map provides:
+
+* lower lookup latency
+* predictable runtime
+* better scalability as the number of parameters grows
+* lower overhead for frequently used ID-based APIs
+
+This is especially useful when parameters are accessed repeatedly from:
+
+* CLI commands
+* host tools
+* diagnostic services
+* communication stacks
+
+### Why this is preferred over binary search
+
+Binary search would require the parameter table to be sorted by ID or an additional sorted lookup table.
+
+That introduces extra maintenance constraints and reduces flexibility in parameter definition order.
+
+The hash-based approach keeps the configuration table simple and preserves fast ID lookup without requiring sorted IDs.
+
+### Collision policy
+
+This implementation uses a strict one-entry-per-bucket hash map.
+
+That means:
+
+* duplicate IDs are rejected
+* hash collisions are also rejected during initialization
+
+If two different IDs map to the same hash bucket, initialization fails and a debug message is printed.
+
+This design keeps runtime lookup logic simple, fast, and deterministic.
+
+### What to do if a hash collision is reported
+
+If initialization prints a message such as:
+
+```text
+ERR, Hash collision: ID X conflicts with ID Y at bucket Z!
+ERR, Please regenerate IDs or adjust hash parameters.
+```
+
+then two different parameter IDs were mapped to the same hash bucket.
+
+Recommended actions:
+
+1. change one or more parameter IDs so they no longer collide
+2. keep subsystem-based ID allocation, but avoid problematic values
+
+In practice, the preferred solution is to **regenerate or reassign the conflicting IDs**.
+
+### Recommended usage
+
+When defining parameter IDs manually:
+
+* keep IDs unique across the entire table
+* keep IDs stable across firmware versions
+* group IDs by subsystem when possible
+* avoid changing IDs unless external compatibility is intentionally broken
+
+### Notes for generated parameter tables
+
+In future workflows, parameter definitions and IDs can be generated by script tools.
+
+When IDs are generated automatically, collisions can be checked during generation, which means:
+
+* duplicate IDs can be prevented before build time
+* hash collisions can be avoided before firmware is compiled
+* the runtime hash map remains simple and fast
+* manual ID maintenance is reduced
+
+With script-generated parameter tables, hash collision problems should normally not occur.
+
+### Design tradeoff
+
+This implementation intentionally favors:
+
+* **fast lookup**
+* **simple runtime logic**
+* **deterministic behavior**
+
+over:
+
+* runtime collision resolution
+* more complex lookup structures
+
+Compared to alternatives such as linear search, linear probing, or maintaining a sorted structure for binary search, this approach gives better lookup performance for normal operation.
+
+The main tradeoff is that a rare hash collision must be resolved by reassigning IDs or regenerating the parameter table. For this module, that tradeoff is considered better than paying additional runtime cost or complexity on every ID lookup.
+
+
  ## **API**
 | API Functions | Description | Prototype |
 | --- | ----------- | ----- |
@@ -221,12 +466,13 @@ static const par_cfg_t g_par_table[ePAR_NUM_OF] =
 
 | Configuration | Description |
 | --- | --- |
-| **PAR_CFG_NVM_EN** 			| Enable/Disable usage of NVM for persistant parameters. |
-| **PAR_CFG_NVM_REGION** 		| Select NVM region for Device Parameter storage space. | 
-| **PAR_CFG_DEBUG_EN** 			| Enable/Disable debugging mode. | 
-| **PAR_CFG_ASSERT_EN** 		| Enable/Disable asserts. Shall be disabled in release build!  | 
-| **PAR_DBG_PRINT** 			| Definition of debug print. | 
-| **PAR_ASSERT** 				| Definition of assert. | 
+| **PAR_CFG_NVM_EN**            | Enable/Disable usage of NVM for persistant parameters. |
+| **PAR_CFG_NVM_REGION**        | Select NVM region for Device Parameter storage space. | 
+| **PAR_CFG_DEBUG_EN**          | Enable/Disable debugging mode. |
+| **PAR_CFG_ASSERT_EN**         | Enable/Disable asserts. Shall be disabled in release build!  | 
+| **PAR_DBG_PRINT**             | Definition of debug print. |
+| **PAR_ASSERT**                | Definition of assert. |
+| **PAR_ATOMIC_BACKEND**        | Select atomic backend implementation. |
 
 **5. Call **par_init()** function**
 

--- a/src/par.c
+++ b/src/par.c
@@ -34,6 +34,43 @@
 ////////////////////////////////////////////////////////////////////////////////
 // Definitions
 ////////////////////////////////////////////////////////////////////////////////
+/*
+ * http://www.citi.umich.edu/techreports/reports/citi-tr-00-1.pdf
+ *
+ * GoldenRatio = ~(Math.pow(2, 32) / ((Math.sqrt(5) - 1) / 2)) + 1
+ */
+#define PAR_ID_HASH_GOLDEN_RATIO_32   ( 0x61C88647u )
+
+/**
+ *  Minimum number of hash buckets to keep target load factor <= 0.5.
+ */
+#define PAR_ID_HASH_MIN_BUCKETS       ((uint32_t)(2u * (uint32_t)ePAR_NUM_OF))
+
+/**
+ *  Hash map geometry derived from ePAR_NUM_OF at compile time.
+ */
+enum
+{
+    PAR_ID_HASH_BITS =
+        ( PAR_ID_HASH_MIN_BUCKETS <= ( 1u << 1  )) ? 1u  :
+        ( PAR_ID_HASH_MIN_BUCKETS <= ( 1u << 2  )) ? 2u  :
+        ( PAR_ID_HASH_MIN_BUCKETS <= ( 1u << 3  )) ? 3u  :
+        ( PAR_ID_HASH_MIN_BUCKETS <= ( 1u << 4  )) ? 4u  :
+        ( PAR_ID_HASH_MIN_BUCKETS <= ( 1u << 5  )) ? 5u  :
+        ( PAR_ID_HASH_MIN_BUCKETS <= ( 1u << 6  )) ? 6u  :
+        ( PAR_ID_HASH_MIN_BUCKETS <= ( 1u << 7  )) ? 7u  :
+        ( PAR_ID_HASH_MIN_BUCKETS <= ( 1u << 8  )) ? 8u  :
+        ( PAR_ID_HASH_MIN_BUCKETS <= ( 1u << 9  )) ? 9u  :
+        ( PAR_ID_HASH_MIN_BUCKETS <= ( 1u << 10 )) ? 10u :
+        ( PAR_ID_HASH_MIN_BUCKETS <= ( 1u << 11 )) ? 11u :
+        ( PAR_ID_HASH_MIN_BUCKETS <= ( 1u << 12 )) ? 12u :
+        ( PAR_ID_HASH_MIN_BUCKETS <= ( 1u << 13 )) ? 13u :
+        ( PAR_ID_HASH_MIN_BUCKETS <= ( 1u << 14 )) ? 14u :
+        ( PAR_ID_HASH_MIN_BUCKETS <= ( 1u << 15 )) ? 15u :
+        ( PAR_ID_HASH_MIN_BUCKETS <= ( 1u << 16 )) ? 16u :
+        ( PAR_ID_HASH_MIN_BUCKETS <= ( 1u << 17 )) ? 17u : 18u,
+    PAR_ID_HASH_SIZE = ( 1u << PAR_ID_HASH_BITS ),
+};
 
 ////////////////////////////////////////////////////////////////////////////////
 // Variables
@@ -52,6 +89,26 @@ static struct
     pf_par_validation_t validation;     /**< Validation callback function (or NULL). */
     pf_par_on_change_cb_t on_change;    /**< On change callback function (or NULL). */
 } g_par_cb_table[ePAR_NUM_OF];
+
+/**
+ *  ID hash map entry.
+ */
+typedef struct
+{
+    uint16_t  id;
+    par_num_t par_num;
+    uint8_t   used;
+} par_id_map_entry_t;
+
+/**
+ *  Runtime ID hash map.
+ */
+static par_id_map_entry_t g_par_id_map[PAR_ID_HASH_SIZE] = {0};
+
+/**
+ *  Initialization guard for ID hash map.
+ */
+static bool gb_par_id_map_ready = false;
 
 /**
  *  Parameter live values divided by its type in RAM
@@ -123,8 +180,11 @@ static uint32_t gu32_par_offset[ ePAR_NUM_OF ] = { 0 };
 ////////////////////////////////////////////////////////////////////////////////
 // Function Prototypes
 ////////////////////////////////////////////////////////////////////////////////
-static void         par_allocate_ram_space          (void);
-static par_status_t par_check_table_validy          (const par_cfg_t * const p_par_cfg);
+static void             par_allocate_ram_space          (void);
+static inline uint32_t  par_hash_id                     (const uint16_t id);
+static par_status_t     par_build_and_validate_id_map   (const par_cfg_t * const p_par_cfg);
+static par_status_t     par_check_table_validy          (const par_cfg_t * const p_par_cfg);
+#if ( 1 == PAR_CFG_NVM_EN )
 static bool         par_is_value_changed            (const par_num_t par_num, const void * p_val);
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -205,6 +265,62 @@ static void par_allocate_ram_space(void)
 
 ////////////////////////////////////////////////////////////////////////////////
 /**
+*        Hash parameter ID to bucket index
+*
+* @param[in]    id  - Parameter ID
+* @return       hash index
+*/
+////////////////////////////////////////////////////////////////////////////////
+static inline uint32_t par_hash_id(const uint16_t id)
+{
+    return (((uint32_t) id * PAR_ID_HASH_GOLDEN_RATIO_32 ) >> ( 32u - PAR_ID_HASH_BITS ));
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/**
+*        Build and validate parameter ID hash map
+*
+* @param[in]    p_par_cfg - Pointer to parameters table
+* @return       status    - Status of operation
+*/
+////////////////////////////////////////////////////////////////////////////////
+static par_status_t par_build_and_validate_id_map(const par_cfg_t * const p_par_cfg)
+{
+    PAR_ASSERT( PAR_ID_HASH_SIZE >= PAR_ID_HASH_MIN_BUCKETS );
+    memset( g_par_id_map, 0, sizeof(g_par_id_map) );
+    for ( par_num_t par_num = 0; par_num < ePAR_NUM_OF; par_num++ )
+    {
+        const uint16_t id = p_par_cfg[par_num].id;
+        const uint32_t bucket_idx = par_hash_id( id );
+        par_id_map_entry_t * const bucket = &g_par_id_map[bucket_idx];
+
+        if ( 0u == bucket->used )
+        {
+            bucket->used = 1u;
+            bucket->id = id;
+            bucket->par_num = par_num;
+            continue;
+        }
+
+        if ( bucket->id == id )
+        {
+            PAR_DBG_PRINT( "ERR, Duplicate parameter ID %u!", (unsigned) id );
+            PAR_ASSERT( 0 );
+            return ePAR_ERROR_INIT;
+        }
+
+        PAR_DBG_PRINT( "ERR, Hash collision: ID %u conflicts with ID %u at bucket %u!",
+            (unsigned) id, (unsigned) bucket->id, (unsigned) bucket_idx );
+        PAR_DBG_PRINT( "ERR, Please regenerate IDs or adjust hash parameters." );
+        PAR_ASSERT( 0 );
+        return ePAR_ERROR_INIT;
+    }
+
+    return ePAR_OK;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/**
 *        Check that parameter table is correctly defined
 *
 * @param[in]    p_par_cfg - Pointer to parameters table
@@ -215,25 +331,16 @@ static par_status_t par_check_table_validy(const par_cfg_t * const p_par_cfg)
 {
     par_status_t status = ePAR_OK;
 
+    // Build and validate runtime ID hash map
+    status = par_build_and_validate_id_map( p_par_cfg );
+    if ( ePAR_OK != status )
+    {
+        return status;
+    }
+
     // For each parameter
     for ( uint32_t i = 0; i < ePAR_NUM_OF; i++ )
     {
-        // Compare parameters IDs
-        for ( uint32_t j = 0; j < ePAR_NUM_OF; j++ )
-        {
-            if ( i != j )
-            {
-                // Check for two identical IDs
-                if ( p_par_cfg[i].id == p_par_cfg[j].id )
-                {
-                    status = ePAR_ERROR_INIT;
-                    PAR_DBG_PRINT( "ERR, Two parameters have the same ID %d!", p_par_cfg[i].id );
-                    PAR_ASSERT( 0 );
-                    break;
-                }
-            }
-        }
-
         /**
          *     Check for correct MIN, MAX and DEF value definitions
          *
@@ -373,6 +480,7 @@ par_status_t par_init(void)
     if ( ePAR_OK == status )
     {
         gb_is_init = true;
+        gb_par_id_map_ready = true;
 
         // Set all parameters to default
         par_set_all_to_default();
@@ -409,6 +517,7 @@ par_status_t par_deinit(void)
 
     // Module de-initialized
     gb_is_init = false;
+    gb_par_id_map_ready = false;
 
     return status;
 }
@@ -1946,17 +2055,15 @@ bool par_is_persistant(const par_num_t par_num)
 ////////////////////////////////////////////////////////////////////////////////
 par_status_t par_get_num_by_id(const uint16_t id, par_num_t * const p_par_num)
 {
-    if ( NULL != p_par_num )
+    if (( NULL != p_par_num ) && ( true == gb_par_id_map_ready ))
     {
-        for (par_num_t par_num = 0; par_num < ePAR_NUM_OF; par_num++ )
-        {
-            const par_cfg_t * const par_cfg = par_get_config(par_num);
+        const uint32_t bucket_idx = par_hash_id( id );
+        const par_id_map_entry_t * const bucket = &g_par_id_map[bucket_idx];
 
-            if (( NULL != par_cfg ) && ( id == par_cfg->id ))
-            {
-                *p_par_num = par_num;
-                return ePAR_OK;
-            }
+        if (( 0u != bucket->used ) && ( id == bucket->id ))
+        {
+            *p_par_num = bucket->par_num;
+            return ePAR_OK;
         }
     }
 


### PR DESCRIPTION
Why to submit this PR 
When the current parameter management module searches for parameters by using the `id`, it usually needs to traverse the entire parameter configuration table and convert the external parameter ID into the internal `par_num`.
This linear search method will result in higher search overhead when the number of parameters increases, and it will also affect the access efficiency in the following scenarios: 
- CLI parameter access
- Upper computer tool reading and writing parameters
- Communication protocol accessing parameters by ID
- Parameter import and export
- Diagnostic and log system 
Furthermore, the current implementation fails to clearly convey the design intention of the parameter ID, the distinction between `par_num` and `id`, and lacks a systematic explanation for the ID lookup mechanism, which makes it difficult for future maintenance and external integration. 
Therefore, this PR is submitted to add an ID lookup mechanism based on a hash table to the parameter module, and to supplement the relevant design documentation for explanation. 
What is your solution? 
This PR mainly made the following adjustments: 
In `README.md`, add a parameter identification design description to clearly distinguish:
- `par_num`: Internal parameter index, used for efficient internal access within the firmware;
- `id`: External parameter identifier, used for external access via CLI, upper-level machine tools, communication protocols, etc. 
2. Add a description of the ID lookup design based on hash table in `README.md`, including:
- Why to use hash table;
- The advantages compared to linear search;
- The trade-offs compared to the binary search scheme;
- The collision resolution strategy and the ID allocation suggestion; 
3. Add the definition related to ID hash to `par.c`: - `PAR_ID_HASH_GOLDEN_RATIO_32`
- `PAR_ID_HASH_MIN_BUCKETS`
- `PAR_ID_HASH_BITS`
- `PAR_ID_HASH_SIZE`

4. New runtime ID hash table data structure: - `par_id_map_entry_t`
- `g_par_id_map[]`
- `gb_par_id_map_ready`

5. A new function `par_hash_id()` has been added, which is used to map parameter IDs to fixed bucket indexes; 
6. A new function `par_build_and_validate_id_map()` has been added. During the initialization stage, it performs the following tasks:
- Traverses the parameter table;
- Builds the mapping of `ID -> par_num`;
- Checks for duplicate IDs;
- Checks for hash conflicts;
- If any issues are found, it returns an initialization error and outputs debugging information. 
7. Adjust `par_check_table_validy()`:
- Remove the previous method of checking duplicate IDs through a double loop;
- Change it to directly build and validate the hash mapping table during initialization; 
8. Add hash table state management in `par_init()` and `par_deinit()`:
- Set `gb_par_id_map_ready = true` after successful initialization
- Clear this state during deinitialization 
9. Optimization of `par_get_num_by_id()`:
- Previously, it searched the entire parameter table to find the matching ID;
- Now, it directly looks up the corresponding `par_num` using a hash bucket;
- If the hash table is ready and the bucket match is successful, the result is returned directly. 
Through the above adjustments, the runtime overhead of the parameter module for ID-based lookup has been significantly reduced. This is particularly suitable for scenarios where there are a large number of parameters and they are frequently accessed through external IDs. At the same time, the new implementation maintains the characteristics of simple runtime logic and strong determinacy. 
Please provide the verified bsp and config (provide the config and bsp) 
- BSP:
Please enter the verified BSP path, for example, `bsp/stm32/stm32l496-st-nucleo` 
- .config:
Please fill in the relevant configuration items used for verifying the parameter management module. 
- action:
Please fill in the link of the CI/Action chain triggered by your own warehouse PR branch.