### PR TITLE
refactor(core): Reorganize parameter manager into core and port layers

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,20 +40,466 @@ NVM module must take following path:
 "root/middleware/nvm/nvm/src/nvm.h"
 ```
 
-### **2. C11 compiler support**
-Parameter module utilize C11 *_Atomic* and *_Generic* features, therefore make sure your compiler supports C11 primitives.  
+### **2. Platform adaptation layer**
+
+This package separates the core parameter logic from platform-specific integration.
+
+Platform-dependent configuration and hooks are provided through the `port/` layer:
+
+* `port/par_cfg_port.h` – platform configuration bridge
+* `port/par_if_port.c` – platform interface backend
+* `port/par_atomic_port.h` – platform atomic backend
+
+This keeps the core module portable while allowing integration with RTOS, mutex, logging, assertion, and atomic services provided by the target platform.
+
+> Note: `parameters/src/par_cfg.h` includes `par_cfg_port.h` unconditionally.
+> You must provide this header in your project include path.
+> If no platform override is required, provide an empty stub `par_cfg_port.h` with include guard.
+
+### **3. Atomic backend configuration**
+
+The module requires an atomic backend for parameter value access.
+
+By default, it uses the C11 atomic backend. If your compiler does not provide usable C11 atomics, or if your platform already provides its own atomic API, you can switch the module to a port-specific backend through `par_atomic_port.h`.
+
+#### When to use `par_atomic_port.h`
+
+Use `par_atomic_port.h` when:
+
+- the compiler does not fully support `<stdatomic.h>`
+- the target platform already provides atomic primitives
+- you want the parameter module to use the RTOS or platform-native atomic implementation
+
+#### How to enable `par_atomic_port.h`
+
+Atomic backend selection is controlled by `PAR_ATOMIC_BACKEND` in `parameters/src/par_atomic.h`.
+
+Available options:
+
+```c
+#define PAR_ATOMIC_BACKEND_C11   1
+#define PAR_ATOMIC_BACKEND_PORT  2
+````
+
+To use the port backend, define:
+
+```c
+#define PAR_ATOMIC_BACKEND PAR_ATOMIC_BACKEND_PORT
+```
+
+After that, `par_atomic.h` will include `par_atomic_port.h` and use the port-provided atomic types and helpers.
+
+#### Notes
+
+* `par_atomic_port.h` must provide all atomic types and operations required by `par_atomic.h`
+* `float32_t` should be stored and loaded by preserving its raw bit representation, not by numeric cast
+* make sure the underlying atomic storage type matches the size of `float`
+* keep all platform-specific atomic adaptation inside `par_atomic_port.h` so the core parameter code does not need to change
 
 ## **Limitations**
  - **Heap Usage:** The module uses malloc during par_init() to allocate RAM space for the parameters based on the configuration table. Ensure your heap is sufficiently sized.
  - **Alignment:** Address offsets are calculated based on 4-byte (32-bit) alignment to satisfy most ARM Cortex-M requirements.
  - **Flat ID Space:** Parameter IDs must be unique across the entire table to ensure NVM consistency.
  - **Execution Time:** If many callbacks are chained to a single parameter, the par_set execution time will increase accordingly.
+ - **Hash-Based ID Lookup:** ID-based lookup is optimized for runtime speed and rejects hash collisions during initialization. See the ID lookup section below.
 
 ## **General Embedded C Libraries Ecosystem**
 In order to be part of *General Embedded C Libraries Ecosystem* this module must be placed in following path: 
 ```
 root/middleware/parameters/parameters/"module_space"
 ```
+
+## Package structure
+
+The package is split into three layers.
+
+### Core layer
+
+Portable parameter logic is implemented under:
+
+```text
+parameters/src/
+```
+
+This layer contains the core implementation of:
+
+* parameter storage and typed access
+* configuration lookup
+* validation and callbacks
+* ID lookup
+* NVM integration
+* atomic abstraction
+* configuration abstraction
+
+### Port layer
+
+Platform-specific integration is implemented under:
+
+```text
+port/
+```
+
+This layer contains:
+
+* `par_cfg_port.h` – platform configuration bridge
+* `par_if_port.c` – platform-specific low-level interface
+* `par_atomic_port.h` – platform-specific atomic backend
+
+This separation keeps the core module portable while isolating platform and RTOS dependencies.
+
+### Template layer
+
+Reference templates are provided under:
+
+```text
+parameters/template/
+```
+
+This layer currently contains:
+
+* `par_cfg.htmp` – configuration header template (default macro layout and comments)
+* `par_cfg.ctmp` – parameter table source template
+* `par_cfg_port.htmp` – port bridge header template
+
+Template files are used as:
+
+* baseline references for keeping generated or manually maintained files aligned with upstream style
+* starting points when creating new `par_cfg.h` / `par_cfg.c` / `par_cfg_port.h` in other projects
+
+Template files are not compiled directly by the runtime library.
+
+---
+
+## Configuration model
+
+The package uses a two-level configuration model.
+
+### Core configuration
+
+Core configuration defaults are defined in:
+
+```text
+parameters/src/par_cfg.h
+```
+
+This file provides default values for options such as:
+
+* `PAR_CFG_NVM_EN`
+* `PAR_CFG_NVM_REGION`
+* `PAR_CFG_TABLE_ID_CHECK_EN`
+* `PAR_CFG_DEBUG_EN`
+* `PAR_CFG_ASSERT_EN`
+* `PAR_CFG_MUTEX_EN`
+* `PAR_CFG_MUTEX_TIMEOUT_MS`
+* `PAR_CFG_IF_PORT_EN`
+* `PAR_CFG_PORT_HOOK_EN`
+
+### Platform bridge
+
+Platform-specific overrides are provided in:
+
+```text
+port/par_cfg_port.h
+```
+
+This file maps platform or build-system configuration symbols to `PAR_CFG_*` options.
+
+`par_cfg_port.h` is mandatory for build because it is directly included by `parameters/src/par_cfg.h`.
+If you do not need overrides, keep a minimal empty file:
+
+```c
+#ifndef _PAR_CFG_PORT_H_
+#define _PAR_CFG_PORT_H_
+/* Optional platform overrides */
+#endif
+```
+
+### Why this split exists
+
+This design keeps the core implementation independent of any single build system or RTOS, while still allowing package-level integration through a dedicated platform bridge.
+
+---
+
+## Port hooks
+
+When `PAR_CFG_PORT_HOOK_EN = 1`, the module uses platform-provided hooks for:
+
+* logging
+* assertions
+* compile-time assertions
+
+The following hooks may be provided by the port layer:
+
+* `PAR_PORT_LOG(...)`
+* `PAR_PORT_ASSERT(x)`
+* `PAR_PORT_STATIC_ASSERT(name, expn)`
+
+This allows the module to integrate with the native debug and assert infrastructure of the target platform.
+
+---
+
+## Interface backend
+
+The low-level interface layer is implemented in `parameters/src/par_if.c`.
+
+When `PAR_CFG_IF_PORT_EN = 1`, the module uses the platform-specific backend provided by:
+
+```text
+port/par_if_port.c
+```
+
+This backend is responsible for platform-dependent services such as:
+
+* initialization
+* mutex handling
+* optional table hash calculation
+
+This keeps the public parameter logic independent from the RTOS or platform implementation.
+
+
+## Parameter identification
+
+Each parameter defined in the configuration table contains two identifiers:
+
+- **par_num** – internal parameter index (enumeration)
+- **id** – external parameter identifier
+
+These identifiers serve different purposes and are intentionally separated.
+
+### Internal identifier (`par_num`)
+
+`par_num` is the enumeration defined in `par_cfg.h` and represents the **internal index of a parameter**.
+
+It is primarily used inside firmware code and by the parameter module APIs.
+
+Example:
+
+```c
+par_set(ePAR_TEST_U8, &value);
+````
+
+Characteristics:
+
+* used as an **index into the parameter configuration table**
+* provides **fast and type-safe access** inside firmware
+* may change if parameters are reordered or new parameters are added
+
+Because of this, `par_num` should generally be used **only inside firmware code**.
+
+### External identifier (`id`)
+
+Each parameter also defines a unique **ID** in the configuration table:
+
+```c
+[ePAR_TEST_U8] = {
+    .id = 0,
+    ...
+}
+```
+
+The **ID is intended for external access** to parameters.
+
+Typical use cases include:
+
+* CLI commands
+* PC configuration tools
+* communication protocols (UART / CAN / etc.)
+* parameter import/export
+* diagnostics or logging
+
+To support these use cases, the module provides APIs that operate using parameter IDs:
+
+* `par_set_by_id()`
+* `par_get_by_id()`
+* `par_save_by_id()`
+
+Internally, these functions resolve the ID to the corresponding `par_num` before accessing the parameter.
+
+### Design rationale
+
+Separating internal and external identifiers provides several advantages:
+
+* **Efficient internal access** through `par_num`
+* **Stable external interface** through `id`
+* the ability to **reorder or extend parameters without breaking external tools**
+
+External systems should always reference parameters by **ID**, while firmware code should typically use **par_num**.
+
+### ID allocation guidelines
+
+Parameter IDs must be **unique across the entire parameter table**.
+
+IDs do not need to be sequential, but it is recommended to group them by subsystem for clarity.
+
+Example allocation:
+
+| ID Range | Subsystem         |
+| -------- | ----------------- |
+| 0–99     | Channel 1         |
+| 100–199  | Channel 2         |
+| 200–299  | Channel 3         |
+| 300–399  | Channel 4         |
+| 10000+   | System parameters |
+
+This approach simplifies integration with external tools and communication protocols.
+
+## ID lookup using hash map
+
+To improve parameter lookup by **ID**, the module builds a runtime hash map during `par_init()`.
+
+This hash map is used by APIs such as:
+
+- `par_get_num_by_id()`
+- `par_set_by_id()`
+- `par_get_by_id()`
+- `par_save_by_id()`
+
+Instead of scanning the full parameter table for every ID lookup, the module hashes the parameter ID and directly maps it to the corresponding `par_num`.
+
+### Why a hash map is used
+
+The parameter module supports two access paths:
+
+- **`par_num`** for internal firmware access
+- **`id`** for external access such as CLI, PC tools, and communication protocols
+
+Internal access by `par_num` is naturally efficient because it uses the parameter enumeration as a direct table index.
+
+External access by **ID** is different. Since IDs are user-defined and do not need to be sequential, converting an ID back to `par_num` would otherwise require a linear search through the full parameter table.
+
+A hash map avoids that cost and provides near constant-time lookup for ID-based APIs.
+
+### How it works
+
+During `par_init()`, the module:
+
+1. walks through the parameter configuration table
+2. hashes each parameter ID into a bucket index
+3. stores the mapping:
+
+```text
+ID -> par_num
+````
+
+Later, when an external API uses an ID, the module:
+
+1. hashes the requested ID
+2. checks the corresponding bucket
+3. returns the mapped `par_num`
+4. performs the actual parameter operation internally
+
+Conceptually:
+
+```text
+External ID
+   |
+   v
+ hash(id)
+   |
+   v
+ hash bucket
+   |
+   v
+ par_num
+   |
+   v
+ internal parameter API
+```
+
+### Why this is better than linear search
+
+Compared to a linear scan of the parameter table, the hash map provides:
+
+* lower lookup latency
+* predictable runtime
+* better scalability as the number of parameters grows
+* lower overhead for frequently used ID-based APIs
+
+This is especially useful when parameters are accessed repeatedly from:
+
+* CLI commands
+* host tools
+* diagnostic services
+* communication stacks
+
+### Why this is preferred over binary search
+
+Binary search would require the parameter table to be sorted by ID or an additional sorted lookup table.
+
+That introduces extra maintenance constraints and reduces flexibility in parameter definition order.
+
+The hash-based approach keeps the configuration table simple and preserves fast ID lookup without requiring sorted IDs.
+
+### Collision policy
+
+This implementation uses a strict one-entry-per-bucket hash map.
+
+That means:
+
+* duplicate IDs are rejected
+* hash collisions are also rejected during initialization
+
+If two different IDs map to the same hash bucket, initialization fails and a debug message is printed.
+
+This design keeps runtime lookup logic simple, fast, and deterministic.
+
+### What to do if a hash collision is reported
+
+If initialization prints a message such as:
+
+```text
+ERR, Hash collision: ID X conflicts with ID Y at bucket Z!
+ERR, Please regenerate IDs or adjust hash parameters.
+```
+
+then two different parameter IDs were mapped to the same hash bucket.
+
+Recommended actions:
+
+1. change one or more parameter IDs so they no longer collide
+2. keep subsystem-based ID allocation, but avoid problematic values
+
+In practice, the preferred solution is to **regenerate or reassign the conflicting IDs**.
+
+### Recommended usage
+
+When defining parameter IDs manually:
+
+* keep IDs unique across the entire table
+* keep IDs stable across firmware versions
+* group IDs by subsystem when possible
+* avoid changing IDs unless external compatibility is intentionally broken
+
+### Notes for generated parameter tables
+
+In future workflows, parameter definitions and IDs can be generated by script tools.
+
+When IDs are generated automatically, collisions can be checked during generation, which means:
+
+* duplicate IDs can be prevented before build time
+* hash collisions can be avoided before firmware is compiled
+* the runtime hash map remains simple and fast
+* manual ID maintenance is reduced
+
+With script-generated parameter tables, hash collision problems should normally not occur.
+
+### Design tradeoff
+
+This implementation intentionally favors:
+
+* **fast lookup**
+* **simple runtime logic**
+* **deterministic behavior**
+
+over:
+
+* runtime collision resolution
+* more complex lookup structures
+
+Compared to alternatives such as linear search, linear probing, or maintaining a sorted structure for binary search, this approach gives better lookup performance for normal operation.
+
+The main tradeoff is that a rare hash collision must be resolved by reassigning IDs or regenerating the parameter table. For this module, that tradeoff is considered better than paying additional runtime cost or complexity on every ID lookup.
+
 
  ## **API**
 | API Functions | Description | Prototype |
@@ -132,10 +578,9 @@ root/middleware/parameters/parameters/"module_space"
 
 ## Usage
 
-**Put all user code between sections: USER CODE BEGIN & USER CODE END!**
+### 1. Define parameter enumeration
 
-**1. Copy template files to root directory of module.**
-**2. List names of all wanted parameters inside **par_cfg.h** file**
+Define the parameter enumeration in `par_def.h`:
 
 ```C
 /**
@@ -149,26 +594,28 @@ root/middleware/parameters/parameters/"module_space"
  */
 typedef enum
 {
-	// USER CODE START...
+    ePAR_TEST_U8 = 0,
+    ePAR_TEST_I8,
 
-	ePAR_TEST_U8 = 0,
-	ePAR_TEST_I8,
+    ePAR_TEST_U16,
+    ePAR_TEST_I16,
 
-	ePAR_TEST_U16,
-	ePAR_TEST_I16,
+    ePAR_TEST_U32,
+    ePAR_TEST_I32,
 
-	ePAR_TEST_U32,
-	ePAR_TEST_I32,
+    ePAR_TEST_F32,
 
-	ePAR_TEST_F32,
-
-	// USER CODE END...
-
-	ePAR_NUM_OF
+    ePAR_NUM_OF
 } par_num_t;
 ```
 
-**3. Change parameter configuration table inside **par_cfg.c** file. It is recommended to use designated initializers.**
+### 2. Define the parameter table
+
+Define the parameter configuration table in `par_def.c`.
+
+It is recommended to use designated initializers.
+
+```C
 
 ```C
 /**
@@ -217,16 +664,49 @@ static const par_cfg_t g_par_table[ePAR_NUM_OF] =
 };
 ```
 
-**4. Set-up all configurations options inside **par_cfg.h** file**
+### 3. Configure the module
+
+The main package configuration is defined in:
+
+```text
+parameters/src/par_cfg.h
+```
+
+Platform-specific overrides and hooks are provided in:
+
+```text
+port/par_cfg_port.h
+```
 
 | Configuration | Description |
 | --- | --- |
-| **PAR_CFG_NVM_EN** 			| Enable/Disable usage of NVM for persistant parameters. |
-| **PAR_CFG_NVM_REGION** 		| Select NVM region for Device Parameter storage space. | 
-| **PAR_CFG_DEBUG_EN** 			| Enable/Disable debugging mode. | 
-| **PAR_CFG_ASSERT_EN** 		| Enable/Disable asserts. Shall be disabled in release build!  | 
-| **PAR_DBG_PRINT** 			| Definition of debug print. | 
-| **PAR_ASSERT** 				| Definition of assert. | 
+| **PAR_CFG_NVM_EN**            | Enable/Disable usage of NVM for persistant parameters. |
+| **PAR_CFG_NVM_REGION**        | Select NVM region for Device Parameter storage space. | 
+| **PAR_CFG_DEBUG_EN**          | Enable/Disable debugging mode. |
+| **PAR_CFG_ASSERT_EN**         | Enable/Disable asserts. Shall be disabled in release build!  | 
+| **PAR_DBG_PRINT**             | Definition of debug print. |
+| **PAR_ASSERT**                | Definition of assert. |
+| **PAR_ATOMIC_BACKEND**        | Select atomic backend implementation. |
+| **PAR_CFG_TABLE_ID_CHECK_EN** | Enable or disable parameter table unique ID checking for NVM compatibility workflows. |
+| **PAR_CFG_MUTEX_EN**          | Enable or disable mutex protection.                                                   |
+| **PAR_CFG_MUTEX_TIMEOUT_MS**  | Mutex timeout in milliseconds.                                                        |
+| **PAR_CFG_IF_PORT_EN**        | Enable platform-specific `par_if` backend.                                            |
+| **PAR_CFG_PORT_HOOK_EN**      | Enable platform log/assert hooks.                                                     |
+
+**4. Build integration**
+
+The package build script collects source files from:
+
+* package root
+* `parameters/src/`
+
+and adds the following include paths:
+
+* package root
+* `parameters/src/`
+* `port/`
+
+If you add or replace port-specific files, keep them under `port/` so they remain visible to the build system.
 
 **5. Call **par_init()** function**
 

--- a/src/par.c
+++ b/src/par.c
@@ -25,15 +25,55 @@
 #include <stdlib.h>
 #include <stdbool.h>
 #include <string.h>
-#include <stdatomic.h>
 
 #include "par.h"
+#include "par_atomic.h"
 #include "par_nvm.h"
-#include "../../par_if.h"
+#include "par_if.h"
 
 ////////////////////////////////////////////////////////////////////////////////
 // Definitions
 ////////////////////////////////////////////////////////////////////////////////
+/*
+ * http://www.citi.umich.edu/techreports/reports/citi-tr-00-1.pdf
+ *
+ * GoldenRatio = ~(Math.pow(2, 32) / ((Math.sqrt(5) - 1) / 2)) + 1
+ */
+#define PAR_ID_HASH_GOLDEN_RATIO_32   ( 0x61C88647u )
+
+/**
+ *  Minimum number of hash buckets to keep target load factor <= 0.5.
+ */
+#define PAR_ID_HASH_MIN_BUCKETS       ((uint32_t)(2u * (uint32_t)ePAR_NUM_OF))
+
+/**
+ *  Hash map geometry derived from ePAR_NUM_OF at compile time.
+ */
+enum
+{
+    PAR_ID_HASH_BITS =
+        ( PAR_ID_HASH_MIN_BUCKETS <= ( 1u << 1  )) ? 1u  :
+        ( PAR_ID_HASH_MIN_BUCKETS <= ( 1u << 2  )) ? 2u  :
+        ( PAR_ID_HASH_MIN_BUCKETS <= ( 1u << 3  )) ? 3u  :
+        ( PAR_ID_HASH_MIN_BUCKETS <= ( 1u << 4  )) ? 4u  :
+        ( PAR_ID_HASH_MIN_BUCKETS <= ( 1u << 5  )) ? 5u  :
+        ( PAR_ID_HASH_MIN_BUCKETS <= ( 1u << 6  )) ? 6u  :
+        ( PAR_ID_HASH_MIN_BUCKETS <= ( 1u << 7  )) ? 7u  :
+        ( PAR_ID_HASH_MIN_BUCKETS <= ( 1u << 8  )) ? 8u  :
+        ( PAR_ID_HASH_MIN_BUCKETS <= ( 1u << 9  )) ? 9u  :
+        ( PAR_ID_HASH_MIN_BUCKETS <= ( 1u << 10 )) ? 10u :
+        ( PAR_ID_HASH_MIN_BUCKETS <= ( 1u << 11 )) ? 11u :
+        ( PAR_ID_HASH_MIN_BUCKETS <= ( 1u << 12 )) ? 12u :
+        ( PAR_ID_HASH_MIN_BUCKETS <= ( 1u << 13 )) ? 13u :
+        ( PAR_ID_HASH_MIN_BUCKETS <= ( 1u << 14 )) ? 14u :
+        ( PAR_ID_HASH_MIN_BUCKETS <= ( 1u << 15 )) ? 15u :
+        ( PAR_ID_HASH_MIN_BUCKETS <= ( 1u << 16 )) ? 16u :
+        ( PAR_ID_HASH_MIN_BUCKETS <= ( 1u << 17 )) ? 17u : 18u,
+    PAR_ID_HASH_SIZE = ( 1u << PAR_ID_HASH_BITS ),
+};
+
+PAR_STATIC_ASSERT(par_id_hash_size_valid, (PAR_ID_HASH_SIZE >= PAR_ID_HASH_MIN_BUCKETS));
+PAR_STATIC_ASSERT(par_id_hash_bits_valid, ((PAR_ID_HASH_BITS > 0u) && (PAR_ID_HASH_BITS < 32u)));
 
 ////////////////////////////////////////////////////////////////////////////////
 // Variables
@@ -54,15 +94,35 @@ static struct
 } g_par_cb_table[ePAR_NUM_OF];
 
 /**
+ *  ID hash map entry.
+ */
+typedef struct
+{
+    uint16_t  id;
+    par_num_t par_num;
+    uint8_t   used;
+} par_id_map_entry_t;
+
+/**
+ *  Runtime ID hash map.
+ */
+static par_id_map_entry_t g_par_id_map[PAR_ID_HASH_SIZE] = {0};
+
+/**
+ *  Initialization guard for ID hash map.
+ */
+static bool gb_par_id_map_ready = false;
+
+/**
  *  Parameter live values divided by its type in RAM
  */
-static _Atomic uint8_t *    gpu8_par_value = NULL;
-static _Atomic int8_t  *    gpi8_par_value = NULL;
-static _Atomic uint16_t *   gpu16_par_value = NULL;
-static _Atomic int16_t  *   gpi16_par_value = NULL;
-static _Atomic uint32_t *   gpu32_par_value = NULL;
-static _Atomic int32_t  *   gpi32_par_value = NULL;
-static _Atomic float32_t *  gpf32_par_value = NULL;
+static par_atomic_u8_t *     gpu8_par_value = NULL;
+static par_atomic_i8_t *     gpi8_par_value = NULL;
+static par_atomic_u16_t *    gpu16_par_value = NULL;
+static par_atomic_i16_t *    gpi16_par_value = NULL;
+static par_atomic_u32_t *    gpu32_par_value = NULL;
+static par_atomic_i32_t *    gpi32_par_value = NULL;
+static par_atomic_f32_t *    gpf32_par_value = NULL;
 
 /**
  *  Address offset by parameter enumeration
@@ -72,29 +132,21 @@ static uint32_t gu32_par_offset[ ePAR_NUM_OF ] = { 0 };
 /**
  *  Private getters and setters
  */
-#define PAR_GET_U8_PRIV(par_num)        atomic_load_explicit( &gpu8_par_value[gu32_par_offset[par_num]], memory_order_relaxed )
-#define PAR_GET_I8_PRIV(par_num)        atomic_load_explicit( &gpi8_par_value[gu32_par_offset[par_num]], memory_order_relaxed )
-#define PAR_GET_U16_PRIV(par_num)       atomic_load_explicit( &gpu16_par_value[gu32_par_offset[par_num]], memory_order_relaxed )
-#define PAR_GET_I16_PRIV(par_num)       atomic_load_explicit( &gpi16_par_value[gu32_par_offset[par_num]], memory_order_relaxed )
-#define PAR_GET_U32_PRIV(par_num)       atomic_load_explicit( &gpu32_par_value[gu32_par_offset[par_num]], memory_order_relaxed )
-#define PAR_GET_I32_PRIV(par_num)       atomic_load_explicit( &gpi32_par_value[gu32_par_offset[par_num]], memory_order_relaxed )
+#define PAR_GET_U8_PRIV(par_num)        PAR_ATOMIC_LOAD(u8, &gpu8_par_value[gu32_par_offset[par_num]])
+#define PAR_GET_I8_PRIV(par_num)        PAR_ATOMIC_LOAD(i8, &gpi8_par_value[gu32_par_offset[par_num]])
+#define PAR_GET_U16_PRIV(par_num)       PAR_ATOMIC_LOAD(u16, &gpu16_par_value[gu32_par_offset[par_num]])
+#define PAR_GET_I16_PRIV(par_num)       PAR_ATOMIC_LOAD(i16, &gpi16_par_value[gu32_par_offset[par_num]])
+#define PAR_GET_U32_PRIV(par_num)       PAR_ATOMIC_LOAD(u32, &gpu32_par_value[gu32_par_offset[par_num]])
+#define PAR_GET_I32_PRIV(par_num)       PAR_ATOMIC_LOAD(i32, &gpi32_par_value[gu32_par_offset[par_num]])
+#define PAR_GET_F32_PRIV(par_num)       PAR_ATOMIC_LOAD(f32, &gpf32_par_value[gu32_par_offset[par_num]])
 
-// NOTICE: "atomic_load_explicit" does not support float data type, therfore using GCC/CLang build-in primitive "__atomic_load" to overcome this limitation
-#define PAR_GET_F32_PRIV(par_num) ({ \
-    float32_t __val; \
-    __atomic_load( &gpf32_par_value[gu32_par_offset[par_num]], &__val, __ATOMIC_RELAXED); \
-    __val; \
-})
-
-#define PAR_SET_U8_PRIV(par_num, val)   atomic_store_explicit( &gpu8_par_value[gu32_par_offset[par_num]], val, memory_order_relaxed )
-#define PAR_SET_I8_PRIV(par_num, val)   atomic_store_explicit( &gpi8_par_value[gu32_par_offset[par_num]], val, memory_order_relaxed )
-#define PAR_SET_U16_PRIV(par_num, val)  atomic_store_explicit( &gpu16_par_value[gu32_par_offset[par_num]], val, memory_order_relaxed )
-#define PAR_SET_I16_PRIV(par_num, val)  atomic_store_explicit( &gpi16_par_value[gu32_par_offset[par_num]], val, memory_order_relaxed )
-#define PAR_SET_U32_PRIV(par_num, val)  atomic_store_explicit( &gpu32_par_value[gu32_par_offset[par_num]], val, memory_order_relaxed )
-#define PAR_SET_I32_PRIV(par_num, val)  atomic_store_explicit( &gpi32_par_value[gu32_par_offset[par_num]], val, memory_order_relaxed )
-
-// NOTICE: "atomic_store_explicit" does not support float data type, therfore using GCC/CLang build-in primitive "__atomic_store" to overcome this limitation
-#define PAR_SET_F32_PRIV(par_num, val)  __atomic_store( &gpf32_par_value[gu32_par_offset[par_num]], &val, memory_order_relaxed )    
+#define PAR_SET_U8_PRIV(par_num, val)   PAR_ATOMIC_STORE(u8, &gpu8_par_value[gu32_par_offset[par_num]], (val))
+#define PAR_SET_I8_PRIV(par_num, val)   PAR_ATOMIC_STORE(i8, &gpi8_par_value[gu32_par_offset[par_num]], (val))
+#define PAR_SET_U16_PRIV(par_num, val)  PAR_ATOMIC_STORE(u16, &gpu16_par_value[gu32_par_offset[par_num]], (val))
+#define PAR_SET_I16_PRIV(par_num, val)  PAR_ATOMIC_STORE(i16, &gpi16_par_value[gu32_par_offset[par_num]], (val))
+#define PAR_SET_U32_PRIV(par_num, val)  PAR_ATOMIC_STORE(u32, &gpu32_par_value[gu32_par_offset[par_num]], (val))
+#define PAR_SET_I32_PRIV(par_num, val)  PAR_ATOMIC_STORE(i32, &gpi32_par_value[gu32_par_offset[par_num]], (val))
+#define PAR_SET_F32_PRIV(par_num, val)  PAR_ATOMIC_STORE(f32, &gpf32_par_value[gu32_par_offset[par_num]], (val))
 
 #if ( PAR_CFG_DEBUG_EN )
 
@@ -123,9 +175,13 @@ static uint32_t gu32_par_offset[ ePAR_NUM_OF ] = { 0 };
 ////////////////////////////////////////////////////////////////////////////////
 // Function Prototypes
 ////////////////////////////////////////////////////////////////////////////////
-static void         par_allocate_ram_space          (void);
-static par_status_t par_check_table_validy          (const par_cfg_t * const p_par_cfg);
+static void             par_allocate_ram_space          (void);
+static inline uint32_t  par_hash_id                     (const uint16_t id);
+static par_status_t     par_build_and_validate_id_map   (const par_cfg_t * const p_par_cfg);
+static par_status_t     par_check_table_validy          (const par_cfg_t * const p_par_cfg);
+#if ( 1 == PAR_CFG_NVM_EN )
 static bool         par_is_value_changed            (const par_num_t par_num, const void * p_val);
+#endif /* ( 1 == PAR_CFG_NVM_EN ) */
 
 ////////////////////////////////////////////////////////////////////////////////
 // Functions
@@ -205,6 +261,61 @@ static void par_allocate_ram_space(void)
 
 ////////////////////////////////////////////////////////////////////////////////
 /**
+*        Hash parameter ID to bucket index
+*
+* @param[in]    id  - Parameter ID
+* @return       hash index
+*/
+////////////////////////////////////////////////////////////////////////////////
+static inline uint32_t par_hash_id(const uint16_t id)
+{
+    return (((uint32_t) id * PAR_ID_HASH_GOLDEN_RATIO_32 ) >> ( 32u - PAR_ID_HASH_BITS ));
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/**
+*        Build and validate parameter ID hash map
+*
+* @param[in]    p_par_cfg - Pointer to parameters table
+* @return       status    - Status of operation
+*/
+////////////////////////////////////////////////////////////////////////////////
+static par_status_t par_build_and_validate_id_map(const par_cfg_t * const p_par_cfg)
+{
+    memset( g_par_id_map, 0, sizeof(g_par_id_map) );
+    for ( par_num_t par_num = 0; par_num < ePAR_NUM_OF; par_num++ )
+    {
+        const uint16_t id = p_par_cfg[par_num].id;
+        const uint32_t bucket_idx = par_hash_id( id );
+        par_id_map_entry_t * const bucket = &g_par_id_map[bucket_idx];
+
+        if ( 0u == bucket->used )
+        {
+            bucket->used = 1u;
+            bucket->id = id;
+            bucket->par_num = par_num;
+            continue;
+        }
+
+        if ( bucket->id == id )
+        {
+            PAR_DBG_PRINT( "ERR, Duplicate parameter ID %u!", (unsigned) id );
+            PAR_ASSERT( 0 );
+            return ePAR_ERROR_INIT;
+        }
+
+        PAR_DBG_PRINT( "ERR, Hash collision: ID %u conflicts with ID %u at bucket %u!",
+            (unsigned) id, (unsigned) bucket->id, (unsigned) bucket_idx );
+        PAR_DBG_PRINT( "ERR, Please regenerate IDs or adjust hash parameters." );
+        PAR_ASSERT( 0 );
+        return ePAR_ERROR_INIT;
+    }
+
+    return ePAR_OK;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/**
 *        Check that parameter table is correctly defined
 *
 * @param[in]    p_par_cfg - Pointer to parameters table
@@ -215,25 +326,16 @@ static par_status_t par_check_table_validy(const par_cfg_t * const p_par_cfg)
 {
     par_status_t status = ePAR_OK;
 
+    // Build and validate runtime ID hash map
+    status = par_build_and_validate_id_map( p_par_cfg );
+    if ( ePAR_OK != status )
+    {
+        return status;
+    }
+
     // For each parameter
     for ( uint32_t i = 0; i < ePAR_NUM_OF; i++ )
     {
-        // Compare parameters IDs
-        for ( uint32_t j = 0; j < ePAR_NUM_OF; j++ )
-        {
-            if ( i != j )
-            {
-                // Check for two identical IDs
-                if ( p_par_cfg[i].id == p_par_cfg[j].id )
-                {
-                    status = ePAR_ERROR_INIT;
-                    PAR_DBG_PRINT( "ERR, Two parameters have the same ID %d!", p_par_cfg[i].id );
-                    PAR_ASSERT( 0 );
-                    break;
-                }
-            }
-        }
-
         /**
          *     Check for correct MIN, MAX and DEF value definitions
          *
@@ -274,6 +376,7 @@ static par_status_t par_check_table_validy(const par_cfg_t * const p_par_cfg)
     return status;
 }
 
+#if ( 1 == PAR_CFG_NVM_EN )
 ////////////////////////////////////////////////////////////////////////////////
 /**
 *        Is parameter value changed
@@ -325,6 +428,7 @@ static bool par_is_value_changed(const par_num_t par_num, const void * p_val)
 
     return value_changed;
 }
+#endif /* ( 1 == PAR_CFG_NVM_EN ) */
 
 ////////////////////////////////////////////////////////////////////////////////
 /**
@@ -373,6 +477,7 @@ par_status_t par_init(void)
     if ( ePAR_OK == status )
     {
         gb_is_init = true;
+        gb_par_id_map_ready = true;
 
         // Set all parameters to default
         par_set_all_to_default();
@@ -409,6 +514,7 @@ par_status_t par_deinit(void)
 
     // Module de-initialized
     gb_is_init = false;
+    gb_par_id_map_ready = false;
 
     return status;
 }
@@ -1177,17 +1283,17 @@ par_status_t par_bitand_set_u8_fast(const par_num_t par_num, const uint8_t val)
 
     if ( val > range.max.u8 )
     {
-        atomic_fetch_and_explicit( &gpu8_par_value[gu32_par_offset[par_num]], range.max.u8, memory_order_relaxed );
+        PAR_ATOMIC_FETCH_AND(u8, &gpu8_par_value[gu32_par_offset[par_num]], range.max.u8);
         return ePAR_WAR_LIMITED;
     }
     else if ( val < range.min.u8 )
     {
-        atomic_fetch_and_explicit( &gpu8_par_value[gu32_par_offset[par_num]], range.min.u8, memory_order_relaxed );
+        PAR_ATOMIC_FETCH_AND(u8, &gpu8_par_value[gu32_par_offset[par_num]], range.min.u8);
         return ePAR_WAR_LIMITED;
     }
     else
     {
-        atomic_fetch_and_explicit( &gpu8_par_value[gu32_par_offset[par_num]], val, memory_order_relaxed );
+        PAR_ATOMIC_FETCH_AND(u8, &gpu8_par_value[gu32_par_offset[par_num]], val);
         return ePAR_OK;
     }
 }
@@ -1210,17 +1316,17 @@ par_status_t par_bitand_set_u16_fast(const par_num_t par_num, const uint16_t val
 
     if ( val > range.max.u16 )
     {
-        atomic_fetch_and_explicit( &gpu16_par_value[gu32_par_offset[par_num]], range.max.u16, memory_order_relaxed );
+        PAR_ATOMIC_FETCH_AND(u16, &gpu16_par_value[gu32_par_offset[par_num]], range.max.u16);
         return ePAR_WAR_LIMITED;
     }
     else if ( val < range.min.u16 )
     {
-        atomic_fetch_and_explicit( &gpu16_par_value[gu32_par_offset[par_num]], range.min.u16, memory_order_relaxed );
+        PAR_ATOMIC_FETCH_AND(u16, &gpu16_par_value[gu32_par_offset[par_num]], range.min.u16);
         return ePAR_WAR_LIMITED;
     }
     else
     {
-        atomic_fetch_and_explicit( &gpu16_par_value[gu32_par_offset[par_num]], val, memory_order_relaxed );
+        PAR_ATOMIC_FETCH_AND(u16, &gpu16_par_value[gu32_par_offset[par_num]], val);
         return ePAR_OK;
     }
 }
@@ -1243,17 +1349,17 @@ par_status_t par_bitand_set_u32_fast(const par_num_t par_num, const uint32_t val
 
     if ( val > range.max.u32 )
     {
-        atomic_fetch_and_explicit( &gpu32_par_value[gu32_par_offset[par_num]], range.max.u32, memory_order_relaxed );
+        PAR_ATOMIC_FETCH_AND(u32, &gpu32_par_value[gu32_par_offset[par_num]], range.max.u32);
         return ePAR_WAR_LIMITED;
     }
     else if ( val < range.min.u32 )
     {
-        atomic_fetch_and_explicit( &gpu32_par_value[gu32_par_offset[par_num]], range.min.u32, memory_order_relaxed );
+        PAR_ATOMIC_FETCH_AND(u32, &gpu32_par_value[gu32_par_offset[par_num]], range.min.u32);
         return ePAR_WAR_LIMITED;
     }
     else
     {
-        atomic_fetch_and_explicit( &gpu32_par_value[gu32_par_offset[par_num]], val, memory_order_relaxed );
+        PAR_ATOMIC_FETCH_AND(u32, &gpu32_par_value[gu32_par_offset[par_num]], val);
         return ePAR_OK;
     }
 }
@@ -1276,17 +1382,17 @@ par_status_t par_bitor_set_u8_fast(const par_num_t par_num, const uint8_t val)
 
     if ( val > range.max.u8 )
     {
-        atomic_fetch_or_explicit( &gpu8_par_value[gu32_par_offset[par_num]], range.max.u8, memory_order_relaxed );
+        PAR_ATOMIC_FETCH_OR(u8, &gpu8_par_value[gu32_par_offset[par_num]], range.max.u8);
         return ePAR_WAR_LIMITED;
     }
     else if ( val < range.min.u8 )
     {
-        atomic_fetch_or_explicit( &gpu8_par_value[gu32_par_offset[par_num]], range.min.u8, memory_order_relaxed );
+        PAR_ATOMIC_FETCH_OR(u8, &gpu8_par_value[gu32_par_offset[par_num]], range.min.u8);
         return ePAR_WAR_LIMITED;
     }
     else
     {
-        atomic_fetch_or_explicit( &gpu8_par_value[gu32_par_offset[par_num]], val, memory_order_relaxed );
+        PAR_ATOMIC_FETCH_OR(u8, &gpu8_par_value[gu32_par_offset[par_num]], val);
         return ePAR_OK;
     }
 }
@@ -1309,17 +1415,17 @@ par_status_t par_bitor_set_u16_fast(const par_num_t par_num, const uint16_t val)
 
     if ( val > range.max.u16 )
     {
-        atomic_fetch_or_explicit( &gpu16_par_value[gu32_par_offset[par_num]], range.max.u16, memory_order_relaxed );
+        PAR_ATOMIC_FETCH_OR(u16, &gpu16_par_value[gu32_par_offset[par_num]], range.max.u16);
         return ePAR_WAR_LIMITED;
     }
     else if ( val < range.min.u16 )
     {
-        atomic_fetch_or_explicit( &gpu16_par_value[gu32_par_offset[par_num]], range.min.u16, memory_order_relaxed );
+        PAR_ATOMIC_FETCH_OR(u16, &gpu16_par_value[gu32_par_offset[par_num]], range.min.u16);
         return ePAR_WAR_LIMITED;
     }
     else
     {
-        atomic_fetch_or_explicit( &gpu16_par_value[gu32_par_offset[par_num]], val, memory_order_relaxed );
+        PAR_ATOMIC_FETCH_OR(u16, &gpu16_par_value[gu32_par_offset[par_num]], val);
         return ePAR_OK;
     }
 }
@@ -1342,17 +1448,17 @@ par_status_t par_bitor_set_u32_fast(const par_num_t par_num, const uint32_t val)
 
     if ( val > range.max.u32 )
     {
-        atomic_fetch_or_explicit( &gpu32_par_value[gu32_par_offset[par_num]], range.max.u32, memory_order_relaxed );
+        PAR_ATOMIC_FETCH_OR(u32, &gpu32_par_value[gu32_par_offset[par_num]], range.max.u32);
         return ePAR_WAR_LIMITED;
     }
     else if ( val < range.min.u32 )
     {
-        atomic_fetch_or_explicit( &gpu32_par_value[gu32_par_offset[par_num]], range.min.u32, memory_order_relaxed );
+        PAR_ATOMIC_FETCH_OR(u32, &gpu32_par_value[gu32_par_offset[par_num]], range.min.u32);
         return ePAR_WAR_LIMITED;
     }
     else
     {
-        atomic_fetch_or_explicit( &gpu32_par_value[gu32_par_offset[par_num]], val, memory_order_relaxed );
+        PAR_ATOMIC_FETCH_OR(u32, &gpu32_par_value[gu32_par_offset[par_num]], val);
         return ePAR_OK;
     }
 }
@@ -1946,17 +2052,15 @@ bool par_is_persistant(const par_num_t par_num)
 ////////////////////////////////////////////////////////////////////////////////
 par_status_t par_get_num_by_id(const uint16_t id, par_num_t * const p_par_num)
 {
-    if ( NULL != p_par_num )
+    if (( NULL != p_par_num ) && ( true == gb_par_id_map_ready ))
     {
-        for (par_num_t par_num = 0; par_num < ePAR_NUM_OF; par_num++ )
-        {
-            const par_cfg_t * const par_cfg = par_get_config(par_num);
+        const uint32_t bucket_idx = par_hash_id( id );
+        const par_id_map_entry_t * const bucket = &g_par_id_map[bucket_idx];
 
-            if (( NULL != par_cfg ) && ( id == par_cfg->id ))
-            {
-                *p_par_num = par_num;
-                return ePAR_OK;
-            }
+        if (( 0u != bucket->used ) && ( id == bucket->id ))
+        {
+            *p_par_num = bucket->par_num;
+            return ePAR_OK;
         }
     }
 

--- a/src/par.h
+++ b/src/par.h
@@ -29,7 +29,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 
-#include "../../par_cfg.h"
+#include "par_cfg.h"
 
 ////////////////////////////////////////////////////////////////////////////////
 // Definitions

--- a/src/par_atomic.h
+++ b/src/par_atomic.h
@@ -1,0 +1,247 @@
+// Copyright (c) 2026 Ziga Miklosic
+// All Rights Reserved
+// This software is under MIT licence (https://opensource.org/licenses/MIT)
+////////////////////////////////////////////////////////////////////////////////
+/**
+*@file      par_atomic.h
+*@brief     Atomic operations API macros and type declarations
+*@author    wdfk-prog
+*@email     1425075683@qq.com
+*@date      09.03.2026
+*@version   V3.0.1
+*@details   This header provides atomic type aliases and helper macros for load,
+*           store, fetch-and, and fetch-or operations. It supports either the
+*           C11 atomic backend or a port-specific backend selected by
+*           PAR_ATOMIC_BACKEND.
+*/
+
+#ifndef PAR_ATOMIC_H
+#define PAR_ATOMIC_H
+
+#include <stdint.h>
+
+////////////////////////////////////////////////////////////////////////////////
+// Definitions
+////////////////////////////////////////////////////////////////////////////////
+
+/**
+ *     C11 atomic backend selector
+ */
+#define PAR_ATOMIC_BACKEND_C11   1
+
+/**
+ *     Port-specific atomic backend selector
+ */
+#define PAR_ATOMIC_BACKEND_PORT  2
+
+#ifndef PAR_ATOMIC_BACKEND
+    /**
+     *     Default atomic backend selection
+     */
+    #define PAR_ATOMIC_BACKEND PAR_ATOMIC_BACKEND_C11
+#endif
+
+/**
+ *     List of integral types supported by atomic load/store helpers
+ *
+ * @param[in]    X - Macro invoked as X(tag, type)
+ */
+#define PAR_ATOMIC_INTEGRAL_TYPE_LIST(X) \
+    X(u8, uint8_t)                       \
+    X(i8, int8_t)                        \
+    X(u16, uint16_t)                     \
+    X(i16, int16_t)                      \
+    X(u32, uint32_t)                     \
+    X(i32, int32_t)
+
+/**
+ *     List of all scalar types supported by atomic helpers
+ *
+ * @param[in]    X - Macro invoked as X(tag, type)
+ */
+#define PAR_ATOMIC_TYPE_LIST(X) \
+    PAR_ATOMIC_INTEGRAL_TYPE_LIST(X) \
+    X(f32, float)
+
+/**
+ *     List of types supported by atomic fetch-and and fetch-or helpers
+ *
+ * @param[in]    X - Macro invoked as X(tag, type)
+ */
+#define PAR_ATOMIC_FETCH_TYPE_LIST(X) \
+    X(u8, uint8_t)                    \
+    X(u16, uint16_t)                  \
+    X(u32, uint32_t)
+
+#if (PAR_ATOMIC_BACKEND == PAR_ATOMIC_BACKEND_C11)
+
+#include <stdatomic.h>
+
+    /**
+     *     Declare atomic typedef for selected scalar type
+     *
+     * @param[in]    tag  - Type tag suffix
+     * @param[in]    type - Scalar type wrapped by _Atomic
+     */
+    #define PAR_ATOMIC_DECLARE_TYPE(tag, type) \
+        typedef _Atomic type par_atomic_##tag##_t;
+
+PAR_ATOMIC_TYPE_LIST(PAR_ATOMIC_DECLARE_TYPE)
+
+    #undef PAR_ATOMIC_DECLARE_TYPE
+
+    /**
+     *     Define atomic load and store helper functions
+     *
+     * @param[in]    tag  - Type tag suffix
+     * @param[in]    type - Scalar type of generated helpers
+     */
+    #define PAR_ATOMIC_DEFINE_LOAD_STORE(tag, type)                                \
+        static inline type par_atomic_load_##tag(const par_atomic_##tag##_t *ptr)  \
+        {                                                                          \
+            return atomic_load_explicit(ptr, memory_order_relaxed);                \
+        }                                                                          \
+                                                                                   \
+        static inline void par_atomic_store_##tag(par_atomic_##tag##_t *ptr,       \
+            type value)                                                            \
+        {                                                                          \
+            atomic_store_explicit(ptr, value, memory_order_relaxed);               \
+        }
+
+PAR_ATOMIC_INTEGRAL_TYPE_LIST(PAR_ATOMIC_DEFINE_LOAD_STORE)
+
+    #undef PAR_ATOMIC_DEFINE_LOAD_STORE
+
+////////////////////////////////////////////////////////////////////////////////
+/**
+*        Load floating-point atomic value
+*
+* @note     "atomic_load_explicit" does not support float data type in this
+*           implementation, therefore GCC/Clang built-in primitive
+*           "__atomic_load" is used instead.
+*
+* @param[in]    ptr - Pointer to atomic floating-point object
+* @return       value - Current floating-point value
+*/
+////////////////////////////////////////////////////////////////////////////////
+static inline float par_atomic_load_f32(const par_atomic_f32_t *ptr)
+{
+    float value;
+
+    __atomic_load(ptr, &value, __ATOMIC_RELAXED);
+
+    return value;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/**
+*        Store floating-point atomic value
+*
+* @note     "atomic_store_explicit" does not support float data type in this
+*           implementation, therefore GCC/Clang built-in primitive
+*           "__atomic_store" is used instead.
+*
+* @param[in]    ptr   - Pointer to atomic floating-point object
+* @param[in]    value - Value to store
+* @return       void
+*/
+////////////////////////////////////////////////////////////////////////////////
+static inline void par_atomic_store_f32(par_atomic_f32_t *ptr, float value)
+{
+    __atomic_store(ptr, &value, __ATOMIC_RELAXED);
+}
+
+    /**
+     *     Define atomic fetch-and helper function
+     *
+     * @param[in]    tag  - Type tag suffix
+     * @param[in]    type - Scalar type of generated helper
+     */
+    #define PAR_ATOMIC_DEFINE_FETCH_AND(tag, type)                                 \
+        static inline type par_atomic_fetch_and_##tag(par_atomic_##tag##_t *ptr,   \
+            type value)                                                            \
+        {                                                                          \
+            return atomic_fetch_and_explicit(ptr, value, memory_order_relaxed);    \
+        }
+
+PAR_ATOMIC_FETCH_TYPE_LIST(PAR_ATOMIC_DEFINE_FETCH_AND)
+
+    #undef PAR_ATOMIC_DEFINE_FETCH_AND
+
+    /**
+     *     Define atomic fetch-or helper function
+     *
+     * @param[in]    tag  - Type tag suffix
+     * @param[in]    type - Scalar type of generated helper
+     */
+    #define PAR_ATOMIC_DEFINE_FETCH_OR(tag, type)                                  \
+        static inline type par_atomic_fetch_or_##tag(par_atomic_##tag##_t *ptr,    \
+            type value)                                                            \
+        {                                                                          \
+            return atomic_fetch_or_explicit(ptr, value, memory_order_relaxed);     \
+        }
+
+PAR_ATOMIC_FETCH_TYPE_LIST(PAR_ATOMIC_DEFINE_FETCH_OR)
+
+    #undef PAR_ATOMIC_DEFINE_FETCH_OR
+
+#elif (PAR_ATOMIC_BACKEND == PAR_ATOMIC_BACKEND_PORT)
+
+#include "../../par_atomic_port.h"
+
+#else
+
+    #error "Unsupported PAR_ATOMIC_BACKEND"
+
+#endif
+
+////////////////////////////////////////////////////////////////////////////////
+/**
+*        Load atomic value by type tag
+*
+* @param[in]    tag - Type tag suffix
+* @param[in]    ptr - Pointer to atomic object
+* @return       value - Current atomic value
+*/
+////////////////////////////////////////////////////////////////////////////////
+#define PAR_ATOMIC_LOAD(tag, ptr)           par_atomic_load_##tag((ptr))
+
+////////////////////////////////////////////////////////////////////////////////
+/**
+*        Store atomic value by type tag
+*
+* @param[in]    tag   - Type tag suffix
+* @param[in]    ptr   - Pointer to atomic object
+* @param[in]    value - Value to store
+* @return       void
+*/
+////////////////////////////////////////////////////////////////////////////////
+#define PAR_ATOMIC_STORE(tag, ptr, value)   par_atomic_store_##tag((ptr), (value))
+
+////////////////////////////////////////////////////////////////////////////////
+/**
+*        Perform atomic fetch-and by type tag
+*
+* @param[in]    tag   - Type tag suffix
+* @param[in]    ptr   - Pointer to atomic object
+* @param[in]    value - Operand for bitwise AND
+* @return       value - Previous atomic value
+*/
+////////////////////////////////////////////////////////////////////////////////
+#define PAR_ATOMIC_FETCH_AND(tag, ptr, value) \
+    par_atomic_fetch_and_##tag((ptr), (value))
+
+////////////////////////////////////////////////////////////////////////////////
+/**
+*        Perform atomic fetch-or by type tag
+*
+* @param[in]    tag   - Type tag suffix
+* @param[in]    ptr   - Pointer to atomic object
+* @param[in]    value - Operand for bitwise OR
+* @return       value - Previous atomic value
+*/
+////////////////////////////////////////////////////////////////////////////////
+#define PAR_ATOMIC_FETCH_OR(tag, ptr, value) \
+    par_atomic_fetch_or_##tag((ptr), (value))
+
+#endif

--- a/src/par_cfg.h
+++ b/src/par_cfg.h
@@ -1,0 +1,246 @@
+// Copyright (c) 2026 Ziga Miklosic
+// All Rights Reserved
+// This software is under MIT licence (https://opensource.org/licenses/MIT)
+////////////////////////////////////////////////////////////////////////////////
+/**
+*@file      par_cfg.h
+*@brief    	Configuration for device parameters
+*@author    Ziga Miklosic
+*@email     ziga.miklosic@gmail.com
+*@date      29.01.2026
+*@version   V3.0.1
+*/
+////////////////////////////////////////////////////////////////////////////////
+/**
+*@addtogroup PAR_CFG
+* @{ <!-- BEGIN GROUP -->
+*
+* 	Configuration for device parameters.
+*/
+////////////////////////////////////////////////////////////////////////////////
+
+#ifndef _PAR_CFG_H_
+#define _PAR_CFG_H_
+
+////////////////////////////////////////////////////////////////////////////////
+// Includes
+////////////////////////////////////////////////////////////////////////////////
+#include <stdint.h>
+#include "par_def.h"
+
+// USER CODE BEGIN...
+
+/**
+ *  Platform adaptation bridge
+ *
+ * @note   Port layer may override default PAR_CFG_* settings.
+ *
+ * @note   This header is included unconditionally.
+ *         Integrator shall provide "par_cfg_port.h" in include path.
+ *         If no platform override is needed, create an empty stub header
+ *         with include guard (for example in port/par_cfg_port.h).
+ */
+#include "par_cfg_port.h"
+
+// USER CODE END...
+
+////////////////////////////////////////////////////////////////////////////////
+// Definitions
+////////////////////////////////////////////////////////////////////////////////
+
+/**
+ *  Enable/Disable storing persistent parameters to NVM
+ */
+#ifndef PAR_CFG_NVM_EN
+    #define PAR_CFG_NVM_EN                          ( 1 )
+#endif
+
+/**
+ *  NVM parameter region option
+ *
+ * @note   User shall select region based on nvm_cfg.h region
+ *         definitions "nvm_region_name_t".
+ *
+ *         Don't care if "PAR_CFG_NVM_EN" set to 0.
+ */
+#ifndef PAR_CFG_NVM_REGION
+    #define PAR_CFG_NVM_REGION                      ( eNVM_REGION_INT_FLASH_DEV_PAR )
+#endif
+
+/**
+ *  Enable/Disable parameter table unique ID checking
+ *
+ * @note   Base on hash unique ID is being calculated with purpose to detect
+ *         device and stored parameter table difference.
+ *
+ *         Must be disabled once the device is released in order to prevent
+ *         loss of calibrated data stored in NVM.
+ *
+ * @pre    "PAR_CFG_NVM_EN" must be enabled otherwise it does not make sense
+ *         to calculate ID at all.
+ */
+#ifndef PAR_CFG_TABLE_ID_CHECK_EN
+    #define PAR_CFG_TABLE_ID_CHECK_EN               ( 0 )
+#endif
+
+#if ( 1 == PAR_CFG_NVM_EN )
+    #ifndef DEBUG
+        #undef PAR_CFG_TABLE_ID_CHECK_EN
+        #define PAR_CFG_TABLE_ID_CHECK_EN          ( 0 )
+    #endif
+#endif
+
+/**
+ *  Enable/Disable debug mode
+ */
+#ifndef PAR_CFG_DEBUG_EN
+    #define PAR_CFG_DEBUG_EN                        ( 1 )
+#endif
+
+#ifndef DEBUG
+    #undef PAR_CFG_DEBUG_EN
+    #define PAR_CFG_DEBUG_EN                        ( 0 )
+#endif
+
+/**
+ *  Enable/Disable assertions
+ */
+#ifndef PAR_CFG_ASSERT_EN
+    #define PAR_CFG_ASSERT_EN                       ( 1 )
+#endif
+
+#ifndef DEBUG
+    #undef PAR_CFG_ASSERT_EN
+    #define PAR_CFG_ASSERT_EN                       ( 0 )
+#endif
+
+/**
+ *  Platform hook fallbacks
+ */
+#ifndef PAR_PORT_ASSERT
+    #define PAR_PORT_ASSERT(x)                      do { (void)(x); } while (0)
+#endif
+
+#ifndef PAR_PORT_LOG
+    #define PAR_PORT_LOG(tag, ...)                  do { (void)(tag); } while (0)
+#endif
+
+#ifndef PAR_PORT_STATIC_ASSERT
+    #define PAR_PORT_STATIC_ASSERT(name, expn)      typedef char _static_assert_##name[(expn) ? 1 : -1]
+#endif
+
+/**
+ *  Package compile-time assert
+ */
+#define PAR_STATIC_ASSERT(name, expn)               PAR_PORT_STATIC_ASSERT(name, expn)
+
+/**
+ *  Resolve log/assert routing mode before default macro emission
+ */
+#if !defined(PAR_CFG_PORT_HOOK_EN)
+    #define PAR_CFG_USE_PORT_HOOKS                  ( 0 )
+#elif ( 1 == PAR_CFG_PORT_HOOK_EN )
+    #define PAR_CFG_USE_PORT_HOOKS                  ( 1 )
+#else
+    #define PAR_CFG_USE_PORT_HOOKS                  ( 0 )
+#endif
+
+/**
+ *  Debug communication port macros
+ */
+#if ( 0 == PAR_CFG_USE_PORT_HOOKS )
+    #if ( 1 == PAR_CFG_DEBUG_EN )
+        #ifndef PAR_CFG_DIRECT_LOG
+            #define PAR_CFG_DIRECT_LOG(...)         ( cli_printf((char *) __VA_ARGS__) )
+        #endif
+        #define PAR_DBG_PRINT(...)                  PAR_CFG_DIRECT_LOG(__VA_ARGS__)
+    #else
+        #define PAR_DBG_PRINT(...)                  { ; }
+    #endif
+#else
+    #if ( 1 == PAR_CFG_DEBUG_EN )
+        #define PAR_DBG_PRINT(...)                  PAR_PORT_LOG(__VA_ARGS__)
+    #else
+        #define PAR_DBG_PRINT(...)                  { ; }
+    #endif
+#endif
+
+/**
+ *  Assertion macros
+ */
+#if ( 0 == PAR_CFG_USE_PORT_HOOKS )
+    #if ( 1 == PAR_CFG_ASSERT_EN )
+        #ifndef PAR_CFG_DIRECT_ASSERT
+            #ifdef PROJ_CFG_ASSERT
+                #define PAR_CFG_DIRECT_ASSERT(x)    PROJ_CFG_ASSERT(x)
+            #else
+                #define PAR_CFG_DIRECT_ASSERT(x)    do { (void)(x); } while (0)
+            #endif
+        #endif
+        #define PAR_ASSERT(x)                       PAR_CFG_DIRECT_ASSERT(x)
+    #else
+        #define PAR_ASSERT(x)                       { ; }
+    #endif
+#else
+    #if ( 1 == PAR_CFG_ASSERT_EN )
+        #define PAR_ASSERT(x)                       PAR_PORT_ASSERT(x)
+    #else
+        #define PAR_ASSERT(x)                       { ; }
+    #endif
+#endif
+
+#undef PAR_CFG_USE_PORT_HOOKS
+
+/**
+ *  Invalid configuration catcher
+ *
+ * @note   Shall be intact by end user!
+ */
+#if ( 0 == PAR_CFG_NVM_EN ) && ( 1 == PAR_CFG_TABLE_ID_CHECK_EN )
+    #error "Parameter settings invalid: Disable table ID checking (PAR_CFG_TABLE_ID_CHECK_EN)!"
+#endif
+
+/**
+ *  Extended package configurations (non-template additions)
+ */
+#ifndef PAR_CFG_MUTEX_EN
+    #define PAR_CFG_MUTEX_EN                        ( 1 )
+#endif
+
+/**
+ *  Parameter mutex timeout
+ *
+ *  Unit: ms
+ */
+#ifndef PAR_CFG_MUTEX_TIMEOUT_MS
+    #define PAR_CFG_MUTEX_TIMEOUT_MS                ( 10 )
+#endif
+
+/**
+ *  Enable/Disable port-specific par_if backend
+ */
+#ifndef PAR_CFG_IF_PORT_EN
+    #define PAR_CFG_IF_PORT_EN                      ( 0 )
+#endif
+
+/**
+ *  Enable/Disable port hooks for log/assert
+ */
+#ifndef PAR_CFG_PORT_HOOK_EN
+    #define PAR_CFG_PORT_HOOK_EN                    ( 0 )
+#endif
+
+////////////////////////////////////////////////////////////////////////////////
+// Functions Prototypes
+////////////////////////////////////////////////////////////////////////////////
+const void * par_cfg_get_table      (void);
+const void * par_cfg_get            (const par_num_t par_num);
+uint32_t     par_cfg_get_table_size (void);
+
+////////////////////////////////////////////////////////////////////////////////
+/**
+* @} <!-- END GROUP -->
+*/
+////////////////////////////////////////////////////////////////////////////////
+
+#endif // _PAR_CFG_H_

--- a/src/par_if.c
+++ b/src/par_if.c
@@ -15,10 +15,10 @@
 *@addtogroup PAR_IF
 * @{ <!-- BEGIN GROUP -->
 *
-* 	Interface layer for device parameters
+*   Interface layer for device parameters
 *
-* 	Put code that is platform depended inside code block start with
-* 	"USER_CODE_BEGIN" and with end of "USER_CODE_END".
+*   Put code that is platform depended inside code block start with
+*   "USER_CODE_BEGIN" and with end of "USER_CODE_END".
 */
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -26,6 +26,12 @@
 // Includes
 ////////////////////////////////////////////////////////////////////////////////
 #include "par_if.h"
+
+#if ( 1 == PAR_CFG_IF_PORT_EN )
+
+#include "par_if_port.c"
+
+#else
 
 // USER INCLUDES BEGIN...
 
@@ -41,11 +47,11 @@
 // USER DEFINITIONS BEGIN...
 
 /**
- * 	Parameter mutex timeout
+ *  Parameter mutex timeout
  *
- * 	Unit: ms
+ *  Unit: ms
  */
-#define PAR_CFG_MUTEX_TIMEOUT_MS				( 10 )
+#define PAR_CFG_MUTEX_TIMEOUT_MS                ( 10 )
 
 // USER DEFINITIONS END...
 
@@ -56,13 +62,13 @@
 // USER VARIABLES BEGIN...
 
 /**
- * 	Parameters OS mutex
+ *  Parameters OS mutex
  */
-static osMutexId_t	g_par_mutex_id = NULL;
+static osMutexId_t g_par_mutex_id = NULL;
 const osMutexAttr_t g_par_mutex_attr =
 {
-    .name 		= "par",
-    .attr_bits 	= ( osMutexPrioInherit ),
+    .name       = "par",
+    .attr_bits  = ( osMutexPrioInherit ),
 };
 
 // USER VARIABLES END...
@@ -73,100 +79,100 @@ const osMutexAttr_t g_par_mutex_attr =
 
 ////////////////////////////////////////////////////////////////////////////////
 /**
-*		Initialize low level interface
+*       Initialize low level interface
 *
-* @note	User shall provide definition of that function based on used platform!
+* @note User shall provide definition of that function based on used platform!
 *
-* @return 		status - Status of initialization
+* @return       status - Status of initialization
 */
 ////////////////////////////////////////////////////////////////////////////////
 par_status_t par_if_init(void)
 {
-	par_status_t status = ePAR_OK;
+    par_status_t status = ePAR_OK;
 
-	// USER CODE BEGIN...
+    // USER CODE BEGIN...
 
-	// Create mutex
-	g_par_mutex_id = osMutexNew( &g_par_mutex_attr );
+    // Create mutex
+    g_par_mutex_id = osMutexNew( &g_par_mutex_attr );
 
-	if ( NULL == g_par_mutex_id )
-	{
-		status = ePAR_ERROR;
-	}
+    if ( NULL == g_par_mutex_id )
+    {
+        status = ePAR_ERROR;
+    }
 
-	// USER CODE END...
+    // USER CODE END...
 
 
-	return status;
+    return status;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /**
-*		Acquire mutex for specified parameter
+*       Acquire mutex for specified parameter
 *
-* @note	User shall provide definition of that function based on used platform!
+* @note User shall provide definition of that function based on used platform!
 *
 *       If mutex is not needed leave empty space between user code begin and end.
 *
 * @param[in]    par_num - Parameter number (enumeration)
-* @return 		status - Status of operation
+* @return       status - Status of operation
 */
 ////////////////////////////////////////////////////////////////////////////////
 par_status_t par_if_aquire_mutex(const par_num_t par_num)
 {
-	par_status_t status = ePAR_OK;
+    par_status_t status = ePAR_OK;
 
-	// USER CODE BEGIN...
+    // USER CODE BEGIN...
     UNUSED(par_num);
-	if ( osOK == osMutexAcquire( g_par_mutex_id, PAR_CFG_MUTEX_TIMEOUT_MS ))
-	{
-		// No action
-	}
-	else
-	{
-		status = ePAR_ERROR;
-	}
+    if ( osOK == osMutexAcquire( g_par_mutex_id, PAR_CFG_MUTEX_TIMEOUT_MS ))
+    {
+        // No action
+    }
+    else
+    {
+        status = ePAR_ERROR;
+    }
 
-	// USER CODE END...
+    // USER CODE END...
 
-	return status;
+    return status;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /**
-*		Release mutex for specified parameter
+*       Release mutex for specified parameter
 *
-* @note	User shall provide definition of that function based on used platform!
+* @note User shall provide definition of that function based on used platform!
 *
 *       If mutex is not needed leave empty space between user code begin and end.
 *
 * @param[in]    par_num - Parameter number (enumeration)
-* @return 		status - Status of operation
+* @return       status - Status of operation
 */
 ////////////////////////////////////////////////////////////////////////////////
 void par_if_release_mutex(const par_num_t par_num)
 {
-	// USER CODE BEGIN...
+    // USER CODE BEGIN...
     UNUSED(par_num);
     osMutexRelease( g_par_mutex_id );
 
-	// USER CODE END...
+    // USER CODE END...
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /**
-*		Calculate hash
+*       Calculate hash
 *
-* @note	User shall provide definition of that function based on used platform!
+* @note User shall provide definition of that function based on used platform!
 *
-* 		If not being used leave empty.
+*       If not being used leave empty.
 *
-* 		This function does not have an affect if "PAR_CFG_TABLE_ID_CHECK_EN"
-* 		is set to 0.
+*       This function does not have an affect if "PAR_CFG_TABLE_ID_CHECK_EN"
+*       is set to 0.
 *
-* @param[in]	p_data	- Pointer to data for hash calculation
-* @param[in]	size	- Size of data in bytes
-* @return 		p_hash	- Pointer to calculated hash number
+* @param[in]    p_data  - Pointer to data for hash calculation
+* @param[in]    size    - Size of data in bytes
+* @return       p_hash  - Pointer to calculated hash number
 */
 ////////////////////////////////////////////////////////////////////////////////
 void par_if_calc_hash(const uint8_t * const p_data, const uint32_t size, uint8_t * const p_hash)
@@ -175,10 +181,12 @@ void par_if_calc_hash(const uint8_t * const p_data, const uint32_t size, uint8_t
     UNUSED( p_hash );
     UNUSED( size );
 
-	// USER CODE BEGIN...
+    // USER CODE BEGIN...
 
-	// USER CODE END...
+    // USER CODE END...
 }
+
+#endif /* ( 1 == PAR_CFG_IF_PORT_EN ) */
 
 ////////////////////////////////////////////////////////////////////////////////
 /**

--- a/src/par_if.h
+++ b/src/par_if.h
@@ -4,7 +4,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 /**
 *@file      par_if.h
-*@brief    	Interface for device parameters
+*@brief     Interface for device parameters
 *@author    Ziga Miklosic
 *@email     ziga.miklosic@gmail.com
 *@date      29.01.2026
@@ -24,7 +24,7 @@
 // Includes
 ////////////////////////////////////////////////////////////////////////////////
 #include <stdint.h>
-#include "parameters/src/par.h"
+#include "par.h"
 #include "par_cfg.h"
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -34,9 +34,9 @@
 ////////////////////////////////////////////////////////////////////////////////
 // Functions Prototypes
 ////////////////////////////////////////////////////////////////////////////////
-par_status_t par_if_init			(void);
-par_status_t par_if_aquire_mutex	(const par_num_t par_num);
-void         par_if_release_mutex	(const par_num_t par_num);
-void 		 par_if_calc_hash		(const uint8_t * const p_data, const uint32_t size, uint8_t * const p_hash);
+par_status_t par_if_init            (void);
+par_status_t par_if_aquire_mutex    (const par_num_t par_num);
+void         par_if_release_mutex   (const par_num_t par_num);
+void         par_if_calc_hash       (const uint8_t * const p_data, const uint32_t size, uint8_t * const p_hash);
 
 #endif // _PAR_IF_H_

--- a/src/par_nvm.c
+++ b/src/par_nvm.c
@@ -54,8 +54,8 @@
 // Includes
 ////////////////////////////////////////////////////////////////////////////////
 #include "par_nvm.h"
-#include "../../par_cfg.h"
-#include "../../par_if.h"
+#include "par_cfg.h"
+#include "par_if.h"
 
 #if ( 1 == PAR_CFG_NVM_EN )
 

--- a/template/par_cfg_port.htmp
+++ b/template/par_cfg_port.htmp
@@ -1,0 +1,4 @@
+#ifndef _PAR_CFG_PORT_H_
+#define _PAR_CFG_PORT_H_
+/* Optional platform overrides */
+#endif

--- a/template/par_def.ctmp
+++ b/template/par_def.ctmp
@@ -3,8 +3,8 @@
 // This software is under MIT licence (https://opensource.org/licenses/MIT)
 ////////////////////////////////////////////////////////////////////////////////
 /**
-*@file      par_cfg.c
-*@brief     Configuration for device parameters
+*@file      par_def.c
+*@brief     Define for device parameters
 *@author    Ziga Miklosic
 *@email     ziga.miklosic@gmail.com
 *@date      29.01.2026
@@ -12,7 +12,7 @@
 */
 ////////////////////////////////////////////////////////////////////////////////
 /**
-*@addtogroup PAR_CFG
+*@addtogroup PAR_DEF
 * @{ <!-- BEGIN GROUP -->
 *
 * 	Configuration for device parameters

--- a/template/par_def.htmp
+++ b/template/par_def.htmp
@@ -3,8 +3,8 @@
 // This software is under MIT licence (https://opensource.org/licenses/MIT)
 ////////////////////////////////////////////////////////////////////////////////
 /**
-*@file      par_cfg.h
-*@brief    	Configuration for device parameters
+*@file      par_def.h
+*@brief    	Define for device parameters
 *@author    Ziga Miklosic
 *@email     ziga.miklosic@gmail.com
 *@date      29.01.2026
@@ -17,8 +17,8 @@
 */
 ////////////////////////////////////////////////////////////////////////////////
 
-#ifndef _PAR_CFG_H_
-#define _PAR_CFG_H_
+#ifndef _PAR_DEF_H_
+#define _PAR_DEF_H_
 
 ////////////////////////////////////////////////////////////////////////////////
 // Includes
@@ -245,92 +245,6 @@ enum
     ePAR_CH_NUM_OF,
 };
 typedef uint8_t par_ch_ref_sel_t;
-
-/**
- * 	Enable/Disable storing persistent parameters to NVM
- */
-#define PAR_CFG_NVM_EN							( 1 )
-
-#if ( 1 == PAR_CFG_NVM_EN )
-	/**
-	 * 	NVM parameter region option
-	 *
-	 * 	@note 	User shall select region based on nvm_cfg.h region
-	 * 			definitions "nvm_region_name_t"
-	 *
-	 * 			Don't care if "PAR_CFG_NVM_EN" set to 0
-	 */
-	#define PAR_CFG_NVM_REGION						( eNVM_REGION_INT_FLASH_DEV_PAR )
-
-	/**
-	 * 	Enable/Disable parameter table unique ID checking
-	 *
-	 * @note	Base on hash unique ID is being calculated with
-	 * 			purpose to detect device and stored parameter table
-	 * 			difference.
-	 *
-	 * 			Must be disabled once the device is release in order
-	 * 			to prevent loss of calibrated data stored in NVM.
-	 *
-	 * 	@pre	"PAR_CFG_NVM_EN" must be enabled otherwise does
-	 * 			not make sense to calculating ID at all.
-	 */
-	#define PAR_CFG_TABLE_ID_CHECK_EN				( 0 )
-
-	#ifndef DEBUG
-	#undef PAR_CFG_TABLE_ID_CHECK_EN
-	#define PAR_CFG_TABLE_ID_CHECK_EN 0
-	#endif
-#endif
-
-/**
- * 	Enable/Disable debug mode
- */
-#define PAR_CFG_DEBUG_EN						( 1 )
-
-#ifndef DEBUG
-#undef PAR_CFG_DEBUG_EN
-#define PAR_CFG_DEBUG_EN 0
-#endif
-
-/**
- * 	Enable/Disable assertions
- */
-#define PAR_CFG_ASSERT_EN						( 1 )
-
-#ifndef DEBUG
-#undef PAR_CFG_ASSERT_EN
-#define PAR_CFG_ASSERT_EN 0
-#endif
-
-/**
- * 	Debug communication port macros
- */
-#if ( 1 == PAR_CFG_DEBUG_EN )
-	#define PAR_DBG_PRINT( ... )				( cli_printf((char*) __VA_ARGS__ ))
-#else
-	#define PAR_DBG_PRINT( ... )				{ ; }
-#endif
-
-/**
- * 	 Assertion macros
- */
-#if ( 1 == PAR_CFG_ASSERT_EN )
-	#define PAR_ASSERT(x)						PROJ_CFG_ASSERT(x)
-#else
-	#define PAR_ASSERT(x)						{ ; }
-#endif
-
-// USER CODE END...
-
-/**
- * 	Invalid configuration catcher
- *
- * 	@note	Shall be intact by end user!
- */
-#if ( 0 == PAR_CFG_NVM_EN ) && ( 1 == PAR_CFG_TABLE_ID_CHECK_EN )
-	#error "Parameter settings invalid: Disable table ID checking (PAR_CFG_TABLE_ID_CHECK_EN)!"
-#endif
 
 ////////////////////////////////////////////////////////////////////////////////
 // Functions Prototypes


### PR DESCRIPTION
### Why to submit this PR
Currently, the directory structure and integration method of the `autogen_parameter_manager` are highly dependent on the platform, and the responsibility boundaries among configuration files, interface files, and template files are not clear enough. This leads to the following issues:
1. The core parameter logic is highly coupled with platform-related implementations, which is not conducive to cross-platform reuse.
2. The configuration overlay methods are not unified, making it less intuitive when integrating into different projects.
3. There is no clear separation between the interface layer and the platform porting layer, which is not conducive to replacing RTOS/platform-related implementations.
4. The boundary between template files and actual runtime code is not clear enough, bringing additional costs to transplantation and maintenance.
5. The documentation lacks sufficient explanations of the package structure, configuration model, and responsibilities of the port layer, which is not conducive to the access of new projects.

Therefore, this PR is submitted to organize the platform adaptation layer and configuration model of the parameter management module, aiming to improve the portability, maintainability, and clarity of project integration of the module.

### What is your solution
This PR mainly makes the following adjustments:
1. Supplement and restructure the module documentation in the README, adding the following contents:
   - Explanation of the platform adaptation layer;
   - Explanation of the package structure;
   - Explanation of the configuration model;
   - Explanation of port hooks;
   - Explanation of the interface backend;
   - Explanation of build integration;
   - Reorganization of the usage method.
2. Define the hierarchical structure of the module:
   - `parameters/src/`: Core parameter logic;
   - `port/`: Platform adaptation layer;
   - `parameters/template/`: Template layer.
3. Add a new core configuration header file `parameters/src/par_cfg.h` for:
   - Providing default `PAR_CFG_*` configurations;
   - Uniformly including `par_cfg_port.h` as the platform configuration bridge;
   - Providing default or ported access methods for log/assert/static assert;
   - Adding extended configuration items such as mutex, interface backend, and port hook.
4. Add a new `parameters/src/par_if.c` as the unified interface layer implementation of the parameter module:
   - When `PAR_CFG_IF_PORT_EN = 1`, use `par_if_port.c` provided by the platform;
   - Otherwise, use the default interface implementation;
   - Provide service entry points for the parameter module, such as initialization, mutex application/release, and optional hash calculation.
5. Adjust `par_if.h` from a template file to a runtime header file `parameters/src/par_if.h`, and synchronously correct the header file reference path.
6. Adjust the inclusion method of core source header files to reduce the dependence on relative paths. For example:
   - Change `../../par_if.h` to `par_if.h`
   - Change `../../par_cfg.h` to `par_cfg.h`
   This is more conducive to the stability of the internal structure of the module and its transplantation.
7. Add compile-time static checks in `par.c`:
   - `PAR_STATIC_ASSERT(par_id_hash_size_valid, ...)`
   - `PAR_STATIC_ASSERT(par_id_hash_bits_valid, ...)`
   Move some original runtime validations to the compile time to improve the timeliness of exposing configuration errors.
8. Add and improve the following template files in the template directory:
   - `par_cfg_port.htmp`
   - `par_def.htmp`
   - `par_def.ctmp`
   These are used for creating parameter definitions, parameter tables, and configuration bridge files in new projects.
9. Emphasize uniformly that `par_cfg_port.h` is the platform bridge header file:
   - It is unconditionally included by `parameters/src/par_cfg.h`;
   - If the project does not require platform overlay, an empty implementation stub file can be provided;
   - Make the configuration overlay path clearer and more consistent.
10. Keep the core logic of the parameter module independent of specific RTOS or project structures, and converge platform-related implementations as much as possible to the `port/` layer to enhance the portability and reusability of the module.

Through the above adjustments, the parameter management module forms a clearer three-layer structure: the core layer, the platform layer, and the template layer. This not only maintains the independence of the core logic but also facilitates rapid integration and customization in different platforms, RTOSs, and projects.

### Provide the config and bsp
- BSP:
  - Please fill in the verified BSP path, for example, `bsp/stm32/stm32l496-st-nucleo`.
- .config:
  - Please fill in the relevant configuration items for verifying the integration of the parameter management module.
  - If port hook, mutex, or interface backend switching is involved, please supplement the corresponding configurations.
- action:
  - Please fill in the CI/Action link triggered by the PR branch of your own repository.